### PR TITLE
Feature/new ons scraper

### DIFF
--- a/features/scrape.feature
+++ b/features/scrape.feature
@@ -3,13 +3,13 @@ Feature: Scrape dataset info
   I want to gather initial information about published data from a web page,
   including the location to fetch the data from.
 
-  Scenario: Scrape ONS
-    Given I scrape the page "https://www.ons.gov.uk/businessindustryandtrade/business/businessinnovation/datasets/foreigndirectinvestmentinvolvingukcompanies2013inwardtables"
+  Scenario: Scrape foo ONS
+    Given I scrape the page "https://www.ons.gov.uk/businessindustryandtrade/business/businessinnovation/datasets/foreigndirectinvestmentinvolvingukcompanies2013inwardtables/data"
     Then the data can be downloaded from "https://www.ons.gov.uk/file?uri=/businessindustryandtrade/business/businessinnovation/datasets/foreigndirectinvestmentinvolvingukcompanies2013inwardtables/current/annualforeigndirectinvestment2017inward.xls"
     And the title should be "Foreign direct investment involving UK companies: inward"
-    And the publication date should be "2018-12-04"
+    #And the publication date should be "2018-12-04"
     And the comment should be "Annual statistics on the investment of foreign companies into the UK, including for investment flows, positions and earnings."
-    And the contact email address should be "mailto:fdi@ons.gov.uk"
+    #And the contact email address should be "mailto:fdi@ons.gov.uk"
 
   Scenario: ONS metadata profile
     Given I scrape the page "https://www.ons.gov.uk/businessindustryandtrade/business/businessinnovation/datasets/foreigndirectinvestmentinvolvingukcompanies2013inwardtables"

--- a/features/scrape.feature
+++ b/features/scrape.feature
@@ -3,13 +3,13 @@ Feature: Scrape dataset info
   I want to gather initial information about published data from a web page,
   including the location to fetch the data from.
 
-  Scenario: Scrape foo ONS
+  Scenario: Scrape ONS
     Given I scrape the page "https://www.ons.gov.uk/businessindustryandtrade/business/businessinnovation/datasets/foreigndirectinvestmentinvolvingukcompanies2013inwardtables/data"
     Then the data can be downloaded from "https://www.ons.gov.uk/file?uri=/businessindustryandtrade/business/businessinnovation/datasets/foreigndirectinvestmentinvolvingukcompanies2013inwardtables/current/annualforeigndirectinvestment2017inward.xls"
     And the title should be "Foreign direct investment involving UK companies: inward"
-    #And the publication date should be "2018-12-04"
+    And the publication date should be "2018-12-04"
     And the comment should be "Annual statistics on the investment of foreign companies into the UK, including for investment flows, positions and earnings."
-    #And the contact email address should be "mailto:fdi@ons.gov.uk"
+    And the contact email address should be "mailto:fdi@ons.gov.uk"
 
   Scenario: ONS metadata profile
     Given I scrape the page "https://www.ons.gov.uk/businessindustryandtrade/business/businessinnovation/datasets/foreigndirectinvestmentinvolvingukcompanies2013inwardtables"

--- a/features/scrape.feature
+++ b/features/scrape.feature
@@ -4,7 +4,7 @@ Feature: Scrape dataset info
   including the location to fetch the data from.
 
   Scenario: Scrape ONS
-    Given I scrape the page "https://www.ons.gov.uk/businessindustryandtrade/business/businessinnovation/datasets/foreigndirectinvestmentinvolvingukcompanies2013inwardtables/data"
+    Given I scrape the page "https://www.ons.gov.uk/businessindustryandtrade/business/businessinnovation/datasets/foreigndirectinvestmentinvolvingukcompanies2013inwardtables"
     Then the data can be downloaded from "https://www.ons.gov.uk/file?uri=/businessindustryandtrade/business/businessinnovation/datasets/foreigndirectinvestmentinvolvingukcompanies2013inwardtables/current/annualforeigndirectinvestment2017inward.xls"
     And the title should be "Foreign direct investment involving UK companies: inward"
     And the publication date should be "2018-12-04"

--- a/features/steps/scrape.py
+++ b/features/steps/scrape.py
@@ -6,7 +6,7 @@ import requests
 from gssutils.metadata import DCTERMS, DCAT, RDFS, namespaces, Excel
 import os
 
-RECORD = 'all'
+RECORD = 'new_episodes'
 
 
 @given('I scrape the page "{uri}"')

--- a/features/steps/scrape.py
+++ b/features/steps/scrape.py
@@ -3,10 +3,10 @@ from gssutils import Scraper
 from nose.tools import *
 import vcr
 import requests
-from gssutils.metadata import DCTERMS, DCAT, RDFS, namespaces
+from gssutils.metadata import DCTERMS, DCAT, RDFS, namespaces, Excel
 import os
 
-RECORD = 'new_episodes'
+RECORD = 'all'
 
 
 @given('I scrape the page "{uri}"')
@@ -18,7 +18,7 @@ def step_impl(context, uri):
 @then('the data can be downloaded from "{uri}"')
 def step_impl(context, uri):
     if not hasattr(context, 'distribution'):
-        context.distribution = context.scraper.distribution()
+        context.distribution = context.scraper.distribution(latest=True, mediaType=Excel)
     assert_equal(context.distribution.downloadURL, uri)
 
 

--- a/gssutils/scrape.py
+++ b/gssutils/scrape.py
@@ -49,7 +49,7 @@ class Scraper:
         logging.basicConfig(format='%(levelname)s:%(message)s', level=log_level)
 
         if debug:
-            logging.debug("Running in debugging mode. Remove the debug=False keyword to change this.")
+            logging.debug("Running in debugging mode. Remove the debug=True keyword to change this.")
 
         self.uri = uri
         self.dataset = PMDDataset()

--- a/gssutils/scrape.py
+++ b/gssutils/scrape.py
@@ -113,7 +113,14 @@ class Scraper:
         for start_uri, scrape in gssutils.scrapers.scraper_list:
             if self.uri.startswith(start_uri):
                 self.dataset.landingPage = self.uri
-                scrape(self, tree)
+
+                # TODO - we should probably be passing through the uri so the scrapers can choose their tools
+                # as an interim, am explicitly passing the uri where its the ONS scraper so we can get the json
+                if start_uri == 'https://www.ons.gov.uk/':
+                    scrape(self, self.uri)
+                else:
+                    scrape(self, tree)
+
                 scraped = True
                 break
         if not scraped:

--- a/gssutils/scrape.py
+++ b/gssutils/scrape.py
@@ -13,7 +13,7 @@ from lxml import html
 from rdflib import BNode, URIRef
 
 import gssutils.scrapers
-from gssutils.metadata import PMDDataset, Excel, ODS, Catalog
+from gssutils.metadata import PMDDataset, Excel, ODS, Catalog, ExcelOpenXML
 from gssutils.utils import pathify
 
 

--- a/gssutils/scrapers/ons.py
+++ b/gssutils/scrapers/ons.py
@@ -15,48 +15,7 @@ ONS_PREFIX = "https://www.ons.gov.uk"
 ONS_DOWNLOAD_PREFIX = ONS_PREFIX+"/file?uri="
 
 
-def scrape(scraper, tree):
-    """
-    This top level scrap-class uses the initial "tree" provided to choose  between using a
-    page-type specific json scraper or using the pre-existing html scraper.
-
-    If the pge is json-able you'll get the handler for the page type you've provided,
-    or you'll get a exception telling you we don't handle it (yet...).
-
-    If it's not json-able, we'll call the older scraper with a depreciation warning.
-
-    :param scraper:     The Scraper Object
-    :param tree:        an lxml etree of the initial scrape
-    :return:
-    """
-
-    # If we can't load it as json we'll have to have to assume it's coming from an older recipe,
-    # so we'll throw a depreciation warning and use the old scraper.
-    try:
-        p = tree.xpath("//p/text()")[0].strip()
-        initial_page = json.loads(p)
-    except:
-        logging.warning("This is not json-able content. Attempting to parse with depreciated html scraper.")
-        depreciated_scraper(scraper, tree)
-        return
-
-    # handers, one per page_type, add to this as needed
-    page_handlers = {
-        "dataset_landing_page": onshandler_dataset_landing_page
-    }
-
-    # throw an exception if it's a json page type we don't handle
-    page_type = initial_page["type"]
-    if page_type not in page_handlers:
-        raise ValueError("Aborting. The ONS scraper does not handle ./data pages of type: " + page_type)
-
-    logging.debug("Calling handler for page type: " + page_type)
-
-    handler = page_handlers[page_type]
-    handler(scraper, initial_page)
-
-
-def onshandler_dataset_landing_page(scraper, landing_page):
+def scrape(scraper, uri):
     """
     This is the handler for the page type of "dataset_landing_page"
 
@@ -65,14 +24,27 @@ def onshandler_dataset_landing_page(scraper, landing_page):
     format type of each previous version of said dataset.
 
     :param scraper:         the Scraper object
-    :param landing_page:    the json representation of a dataset_landing_page
+    :param landing_page:    lxml etree
     :return:
     """
 
-    # sanity check, make sure the page really is just dealing with one dataset
-    if len(landing_page["datasets"]) != 1:
-        raise ValueError("Aborting. More than one dataset linked on a dataset landing page: {}." \
-                         .format(",".join(landing_page["datasets"])))
+    # If we can't load it as json we'll have to have to assume it's coming from an older recipe,
+    # so we'll throw a depreciation warning and use the old scraper.
+
+    r = requests.get(uri + "/data")
+    if r.status_code != 200:
+        raise ValueError("Aborting. Issue encountered while attempting to scrape '{}'. Http code" \
+                         "returned was '{}.".format(uri+"/data", r.status_code))
+    try:
+        landing_page = r.json()
+    except Exception as e:
+        raise ValueError("Aborting operation This is not json-able content.") from e
+
+    # throw an exception if it's a json page type we don't handle
+    page_type = landing_page["type"]
+    if page_type.strip() != "dataset_landing_page":
+        raise ValueError("Aborting. The ONS scraper handles pages of /data json type " \
+                         "'dataset_landing_page', not {}."+ page_type)
 
     # Acquire basic metadata from the dataset_landing_page
     scraper.dataset.title = landing_page["description"]["title"].strip()
@@ -80,155 +52,72 @@ def onshandler_dataset_landing_page(scraper, landing_page):
     scraper.dataset.issued = parse(landing_page["description"]["releaseDate"]).date()
     scraper.dataset.comment = landing_page["description"]["summary"].strip()
 
-    # next release is sometimes blank, so use a conditional
-    if landing_page["description"]["nextRelease"] != "":
+    # next release is sometimes blank or a string, so use a conditional before parsing time
+    if landing_page["description"]["nextRelease"] != "To be announced" and \
+            landing_page["description"]["nextRelease"] != "":
         scraper.dataset.updateDueOn = parse(landing_page["description"]["nextRelease"])
+
 
     # get contact info now, as it's only available via json at the landing_page level
     # note, adding mailto: prefix so the property gets correctly identified by metadata.py
     contact_dict = landing_page["description"]["contact"]
     scraper.dataset.contactPoint = "mailto:"+contact_dict["email"]
 
-    # Get json "scrape" of the ./current page
-    page_url = ONS_PREFIX+landing_page["datasets"][0]["uri"]+"/data"
-    r = requests.get(page_url)
-    if r.status_code != 200:
-        raise ValueError("Scrape of url '{}' failed with status code {}." \
-                         .format(page_url, r.status_code))
+    # Get json "scrape" of the "datasets"
+    for dataset_page_url in landing_page["datasets"]:
 
-    current_dataset_page = r.json() # dict-ify
-
-    # start a dictionary of dataset versions (to hold current + all previous) as
-    # {url: release_date}, start with just the current/latest version
-    versions_dict = {ONS_PREFIX + landing_page["datasets"][0]["uri"]+"/data":
-                                    landing_page["description"]["releaseDate"]}
-
-    # then add all the older version to that dictionary
-    for version_as_dict in current_dataset_page["versions"]:
-        versions_dict.update({ONS_PREFIX+version_as_dict["uri"]+"/data":
-                                    version_as_dict["updateDate"]})
-
-    # iterate through the lot, creating a distribution objects for each
-    # then add it to the list scraper.distributions[]
-    for distro_url, release_date in versions_dict.items():
-        logging.debug("Identified distribution url, building distribution object for: " + distro_url)
-
-        r = requests.get(distro_url)
+        dataset_page_json_url = ONS_PREFIX+dataset_page_url["uri"]+"/data"
+        r = requests.get(dataset_page_json_url)
         if r.status_code != 200:
-            raise ValueError("Aborting. Scraper unable to acquire the page: "+ distro_url)
+            raise ValueError("Scrape of url '{}' failed with status code {}." \
+                             .format(dataset_page_json_url, r.status_code))
 
-        this_page = r.json()    # dict-ify
+        this_dataset_page = r.json() # dict-ify
 
-        # Get the download urls, if there's more than 1,each forms a separate distribution
-        distribution_formats = this_page["downloads"]
-        for dl in distribution_formats:
+        # start a dictionary of dataset versions (to hold current + all previous) as
+        # {url: release_date}, start with just the current/latest version
+        versions_dict = {ONS_PREFIX + this_dataset_page["uri"]+"/data":
+                                        landing_page["description"]["releaseDate"]}
 
-            # Distribution object to represent this distribution
-            this_distribution = Distribution(scraper)
-            this_distribution.issued = parse(release_date.strip()).date()
+        # then add all the older version to that dictionary
+        for version_as_dict in this_dataset_page["versions"]:
+            versions_dict.update({ONS_PREFIX+version_as_dict["uri"]+"/data":
+                                        version_as_dict["updateDate"]})
 
-            assert 'file' in dl.keys(), "Aborting, expecting dict with 'file' key. Instead " \
-                    + "we got: {}.".format(str(dl))
+        # iterate through the lot, creating a distribution objects for each
+        # then add it to the list scraper.distributions[]
+        for distro_url, release_date in versions_dict.items():
+            logging.debug("Identified distribution url, building distribution object for: " + distro_url)
 
-            download_url = ONS_DOWNLOAD_PREFIX+this_page["uri"]+"/"+dl["file"]
-            this_distribution.downloadURL = download_url
-            this_distribution.mediaType, encoding = mimetypes.guess_type(this_distribution.downloadURL)
+            r = requests.get(distro_url)
+            if r.status_code != 200:
+                raise ValueError("Aborting. Scraper unable to acquire the page: "+ distro_url)
 
-            # inherit metadata from the dataset where it hasn't explicitly been changed
-            this_distribution.title = scraper.dataset.title
-            this_distribution.description = scraper.dataset.description
-            this_distribution.contactPoint = scraper.dataset.contactPoint
+            this_page = r.json()    # dict-ify
 
-            logging.debug("Created distribution for download '{}'.".format(download_url))
-            scraper.distributions.append(this_distribution)
+            # Get the download urls, if there's more than 1,each forms a separate distribution
+            distribution_formats = this_page["downloads"]
+            for dl in distribution_formats:
 
-    # boiler plate
-    scraper.dataset.publisher = 'https://www.gov.uk/government/organisations/office-for-national-statistics'
+                # Distribution object to represent this distribution
+                this_distribution = Distribution(scraper)
+                this_distribution.issued = parse(release_date.strip()).date()
 
+                assert 'file' in dl.keys(), "Aborting, expecting dict with 'file' key. Instead " \
+                        + "we got: {}.".format(str(dl))
 
-# depreciated, but keeping it is an optional so we don't break the world
-def depreciated_scraper(scraper, tree):
-    scraper.dataset.title = tree.xpath(
-        "//h1/text()")[0].strip()
-    scraper.dataset.issued = parse(tree.xpath(
-        "//span[starts-with(text(),'Release date:')]/parent::node()/text()")[1].strip()).date()
-    user_requested = tree.xpath(
-        "//h2[starts-with(text(),'Summary of request')]"
-    )
+                download_url = ONS_DOWNLOAD_PREFIX+this_page["uri"]+"/"+dl["file"]
+                this_distribution.downloadURL = download_url
+                this_distribution.mediaType, encoding = mimetypes.guess_type(this_distribution.downloadURL)
 
-    if len(user_requested) > 0:
-        scraper.dataset.identifier = tree.xpath(
-            "//span[starts-with(text(), 'Reference number:')]/parent::node()/text()")[1].strip()
-        scraper.dataset.comment = tree.xpath(
-            "//h2[starts-with(text(), 'Summary of request')]/following-sibling::p/text()")[0].strip()
-        distribution_link = tree.xpath(
-            "//h2[starts-with(text(), 'Download associated with request')]/following-sibling::*/descendant::a")
-        if len(distribution_link) > 0:
-            distribution = Distribution(scraper)
-            distribution.downloadURL = urljoin(scraper.uri, distribution_link[0].get('href'))
-            distribution.title = distribution_link[0].text
-            distribution_info = distribution_link[0].xpath(
-                "following-sibling::text()")
-            if len(distribution_info) > 0:
-                info_text = distribution_info[0].strip()
-                info_re = re.compile(r'\(([0-9\.])+\s+([kMG]B)\s+(xls|ods|pdf)\)')
-                info_match = info_re.match(info_text)
-                if info_match is not None:
-                    size, units, file_type = info_match.groups()
-                    if units == 'kB':
-                        distribution.byteSize = size * 1024
-                    elif units == 'MB':
-                        distribution.byteSize = size * 1000000
-                    if file_type == 'xls':
-                        distribution.mediaType = Excel
-                    elif file_type == 'ods':
-                        distribution.mediaType = ODS
-                    else:
-                        distribution.mediaType, encoding = mimetypes.guess_type(distribution.downloadURL)
-            scraper.distributions.append(distribution)
-    else:
-        try:
-            scraper.dataset.updateDueOn = parse(tree.xpath(
-                "//span[starts-with(text(),'Next release:')]/parent::node()/text()")[1].strip()).date()
-        except ValueError as e:
-            logging.warning('Unexpected "next release" field: ' + str(e))
-        except IndexError:
-            logging.warning('Unable to find "next release" field')
-        try:
-            mailto = tree.xpath(
-                "//span[starts-with(text(),'Contact:')]/following-sibling::a[1]/@href")[0].strip()
-            # guard against extraneous, invalid spaces
-            scraper.dataset.contactPoint = re.sub(r'^mailto:\s+', 'mailto:', mailto)
-        except IndexError:
-            logging.warning('Unable to find "contact" field.')
-        scraper.dataset.comment = tree.xpath(
-            "//h2[starts-with(text(),'About this dataset')]/following-sibling::p/text()")[0].strip()
+                # inherit metadata from the dataset where it hasn't explicitly been changed
+                this_distribution.title = scraper.dataset.title
+                this_distribution.description = scraper.dataset.description
+                this_distribution.contactPoint = scraper.dataset.contactPoint
 
-        for anchor in tree.xpath("//a[starts-with(@title, 'Download as ')]"):
-            distribution = Distribution(scraper)
-            distribution.downloadURL = urljoin(scraper.uri, anchor.get('href'))
-            type_size_re = re.compile(r'([^(]*)\(([0-9.]+)\s+([^s]+)\)')
-            type_size_match = type_size_re.match(anchor.text)
-            if type_size_match is not None:
-                typ, size, mult = type_size_match.groups()
-                if mult == 'kB':
-                    distribution.byteSize = float(size) * 1024
-                elif mult == 'MB':
-                    distribution.byteSize = float(size) * 1000000
-                else:
-                    distribution.byteSize = float(size)
-                if typ.strip() == 'csv':
-                    distribution.mediaType = CSV
-                elif typ.strip() == 'xlsx':
-                    distribution.mediaType = Excel
-                elif typ.strip() == 'ods':
-                    distribution.mediaType = ODS
-                elif typ.strip() == 'structured text':
-                    distribution.mediaType = CSDB
-                else:
-                    distribution.mediaType, encoding = mimetypes.guess_type(distribution.downloadURL)
-            distribution.title = scraper.dataset.title
-            scraper.distributions.append(distribution)
-    scraper.dataset.publisher = 'https://www.gov.uk/government/organisations/office-for-national-statistics'
-    scraper.dataset.license = tree.xpath(
-        "//div[@class='footer-license']//a")[0].get('href')
+                logging.debug("Created distribution for download '{}'.".format(download_url))
+                scraper.distributions.append(this_distribution)
+
+        # boiler plate
+        scraper.dataset.publisher = 'https://www.gov.uk/government/organisations/office-for-national-statistics'
+

--- a/gssutils/scrapers/ons.py
+++ b/gssutils/scrapers/ons.py
@@ -126,53 +126,8 @@ def onshandler_dataset_landing_page(scraper, landing_page):
             assert 'file' in dl.keys(), "Aborting, expecting dict with 'file' key. Instead " \
                     + "we got: {}.".format(str(dl))
 
-
             download_url = ONS_DOWNLOAD_PREFIX+this_page["uri"]+"/"+dl["file"]
             this_distribution.downloadURL = download_url
-            this_distribution.mediaType = download_url.split('.')[1]
-
-            # Get file size
-            """
-            # TODO - better, this is a bit nasty.
-
-            It's because my old pal zebedee (ONS content file server) is resisting all
-            attempts to give out file information beyond letting you download the file.
-
-            Am having to switch back to the html page and nip out the hard coded file size.
-            """
-
-            lines_in_html_page = [x for x in requests.get(distro_url[:-5]).text.split("\n")]
-
-            file_extension_sought = download_url.split(".")[-1]
-            file_size_text = None
-
-            for i in range(0, len(lines_in_html_page)):
-                if "MB)" in lines_in_html_page[i]:
-                    previous_line = lines_in_html_page[i-1]
-
-                    # the text for csv or xlsx should match the file type
-                    if previous_line.strip() == file_extension_sought:
-                        file_size_text = lines_in_html_page[i]
-
-                    # otherwise specifically check it its csdb
-                    elif previous_line.strip() == "text" and file_extension_sought == "csdb":
-                        file_size_text = lines_in_html_page[i]
-
-            assert file_size_text != None, "Unable to find file size for '{}' from '{}'." \
-                    .format(download_url, distro_url[:-5])
-
-            # We'll use a wordy try catch as this is the bit most likely to blow up
-            should_be_floatable = file_size_text[1:].split(" ")[0]
-            try:
-                this_distribution.byteSize = float(should_be_floatable) * 1000
-            except ValueError as ve:
-                raise ValueError("Issue encountered attempting to turn '{}' from '{}' into float. "
-                            "Source page was '{}', for source format '{}'.".format(should_be_floatable,
-                                                file_size_text, distro_url[:-5], dl["file"])) from ve
-
-            logging.debug("Captured filesize for '{}' as '{}'".format(distro_url,
-                            str(this_distribution.byteSize)))
-
             this_distribution.mediaType, encoding = mimetypes.guess_type(this_distribution.downloadURL)
 
             # inherit metadata from the dataset where it hasn't explicitly been changed

--- a/gssutils/scrapers/ons.py
+++ b/gssutils/scrapers/ons.py
@@ -78,7 +78,10 @@ def onshandler_dataset_landing_page(scraper, landing_page):
     scraper.dataset.title = landing_page["description"]["title"]
     scraper.dataset.description = landing_page["description"]["metaDescription"]
     scraper.dataset.issued = parse(landing_page["description"]["releaseDate"])
-    scraper.dataset.updateDueOn = parse(landing_page["description"]["nextRelease"])
+
+    # next release is sometimes blank, so use a conditional
+    if landing_page["description"]["nextRelease"] != "":
+        scraper.dataset.updateDueOn = parse(landing_page["description"]["nextRelease"])
 
     # get contact info now, as it's only available via json at the landing_page level
     # note, adding mailto: prefix so the property gets correctly identified by metadata.py

--- a/gssutils/scrapers/ons.py
+++ b/gssutils/scrapers/ons.py
@@ -7,8 +7,163 @@ from dateutil.parser import parse
 
 from gssutils.metadata import Distribution, Excel, ODS, CSV, CSDB
 
+import requests
+
+import json
+
+ONS_PREFIX = "http://www.ons.gov.uk"
+ONS_DOWNLOAD_PREFIX = ONS_PREFIX+"/file?uri="
+
+def prefered_distribution_type(list_of_urls):
+    """
+    Helper function, where a distribution is available in multiple formats we need to pick one.
+    # TODO: something of this ilk probably makes more sense as a global resource
+
+    For now, I'm going with a preference of excel over csv and blow up for neither. But we might
+    need to be a bit cleverer than that.
+
+    :param list_of_urls:     list of truncated url endpoints with different formats
+    :return use_me:          the chosen truncated url endpoint
+    """
+
+    reverse_ordered_suffix_preferences = [".csv", "xls", ".xlsx"]
+    use_me = None
+    for url_in_dict in list_of_urls:
+        url = next(iter(url_in_dict.values()))
+        for prefered_suffix in reverse_ordered_suffix_preferences:
+            if url.endswith(prefered_suffix):
+                use_me = url
+
+    if use_me == None:
+        raise ValueError("Aborting operation. Could not find a supported type from '{}' in" \
+                "any of '{}'.".format(",".join(reverse_ordered_suffix_preferences), ",".join(list_of_urls)))
+
+    return use_me
+
 
 def scrape(scraper, tree):
+    """
+    The ONS pages vary a bit, they're (nearly!) all availible in json but they have distinct
+    'types'. Rather than trying to account for the journey from every single type that we might
+    start from (possible, but spagetti), I'm putting in a switch.
+
+    Basically, you'll get the handler for the page type you've provided. Or you'll get a
+    exception telling you we don't handle it.
+
+    :param scraper:     The Scraper Object
+    :param tree:        an lxml tree of the initial scrape
+    :return:
+    """
+
+    # If we can't load it as json we'll have to have to assume it's coming from an older recipe,
+    # so we'll throw a depreciation warning and use the old scraper.
+    try:
+        p = tree.xpath("//p/text()")[0].strip()
+        initial_page = json.loads(p)
+    except:
+        scraper.logger.warning("This is not json-able content. Attempting to parse with depreciated html scraper.")
+        depreciated_scraper(scraper, tree)
+        return
+
+    # note - add as needed
+    page_handlers = {
+        "dataset_landing_page": onshandler_dataset_landing_page
+    }
+
+    page_type = initial_page["type"]
+
+    if page_type not in page_handlers:
+        raise ValueError("Aborting. The ONS scraper does not handle ./data pages of type: " + page_type)
+
+    scraper.logger.debug("Calling handler for page type: " + page_type)
+
+    handler = page_handlers[page_type]
+    handler(scraper, initial_page)
+
+
+def onshandler_dataset_landing_page(scraper, landing_page):
+    """
+    This is the handler for the page type of "dataset_landing_page"
+
+    The intention is to get the basic metadata from this page, then look at the provided
+    /current link to get the specific distributions with distribution-level metadata
+
+    :param scraper:         the Scraper object
+    :param landing_page:    the /data representation of this page
+    :return:
+    """
+
+    # sanity check, in case we do something silly
+    if landing_page["type"] != "dataset_landing_page":
+        raise ValueError("Aborting. Scraper is expecting to start on page of type 'dataset_landing_page'" \
+                "not '{}'.".format(landing_page["type"]))
+
+    # sanity check, in case they do something silly
+    if len(landing_page["datasets"]) != 1:
+        raise ValueError("Aborting. More than one dataset linked on a dataset landing page: {}." \
+                         .format(",".join(landing_page["datasets"])))
+
+    # Acquire basic metadata from dataset_landing_page
+    scraper.dataset.title = landing_page["description"]["title"]
+    scraper.dataset.issued = landing_page["description"]["releaseDate"] # TODO time format
+
+    # Get json "scrape" of the ./current page
+    page_url = ONS_PREFIX+landing_page["datasets"][0]["uri"]+"/data"
+    r = requests.get(page_url)
+    if r.status_code != 200:
+        raise ValueError("Scrape of url '{}' failed with status code {}.".format(page_url, r.status_code))
+
+    current_dataset_page = r.json() # dict-ify
+
+    distributions_url_list = [ONS_PREFIX + landing_page["datasets"][0]["uri"]+"/data"]
+    for version_as_dict in current_dataset_page["versions"]:
+        distributions_url_list.append(ONS_PREFIX+version_as_dict["uri"]+"/data")
+
+    # now we've got a list of distributions as urls, lets create those objects
+    for distro_url in distributions_url_list:
+        scraper.logger.debug("Identified distribution url, building distribution object for: " + distro_url)
+
+        r = requests.get(distro_url)
+        if r.status_code != 200:
+            raise ValueError("Aborting. Scraper unable to acquire the page: "+ distro_url)
+
+        this_page = r.json()    # dict-ify
+
+        # Distribution object to represent this distribution
+        this_distribution = Distribution(scraper)
+
+        # Get the download url (use our preference where there're multiple formats)
+        distribution_formats = this_page["downloads"]
+        chosen_format_endpoint = prefered_distribution_type(distribution_formats)
+        download_url = ONS_DOWNLOAD_PREFIX+this_page["uri"]+"/"+chosen_format_endpoint
+        this_distribution.downloadURL = download_url
+        this_distribution.mediaType = download_url.split('.')[1]
+
+        # Get file size
+        """
+        # TODO - this is a bit nasty.
+        
+        It's because my old pal zebedee (ONS content file server) is resisting all attempts to give
+        out file information beyond letting you download the whole thing.
+        
+        Am having to switch back to the html page and nip out the hard coded file size.
+        """
+        lines_in_html_page = [x for x in requests.get(distro_url[:-5]).text.split("\n")]
+        file_size_text = None
+        for i in range(0, len(lines_in_html_page)):
+            if 'data-gtm-date="Latest"' in lines_in_html_page[i]:
+                file_size_text = lines_in_html_page[i+2]
+                break
+        this_distribution.byteSize = float(file_size_text[1:].split(" ")[0]) * 1000
+
+        scraper.distributions.append(this_distribution)
+
+    # boiler plate
+    scraper.dataset.publisher = 'https://www.gov.uk/government/organisations/office-for-national-statistics'
+
+
+# depreciated, but keeping it is an optional so we don't break the world
+def depreciated_scraper(scraper, tree):
     scraper.dataset.title = tree.xpath(
         "//h1/text()")[0].strip()
     scraper.dataset.issued = parse(tree.xpath(

--- a/gssutils/scrapers/ons.py
+++ b/gssutils/scrapers/ons.py
@@ -173,21 +173,12 @@ def onshandler_dataset_landing_page(scraper, landing_page):
             logging.debug("Captured filesize for '{}' as '{}'".format(distro_url,
                             str(this_distribution.byteSize)))
 
-            # We'll get the mediaType from the file extension
-            file_types = {
-                ".csv": CSV,
-                ".xlsx": Excel,
-                ".ods": ODS,
-                ".csdb": CSDB
-            }
-            for ft in file_types:
-                if download_url.endswith(ft):
-                    this_distribution.mediaType = file_types[ft]
+            this_distribution.mediaType, encoding = mimetypes.guess_type(this_distribution.downloadURL)
 
             # inherit metadata from the dataset where it hasn't explicitly been changed
             this_distribution.title = scraper.dataset.title
             this_distribution.description = scraper.dataset.description
-            this_distribution.contactPoint = "mailto:" + contact_dict["email"]
+            this_distribution.contactPoint = scraper.dataset.contactPoint
 
             logging.debug("Created distribution for download '{}'.".format(download_url))
             scraper.distributions.append(this_distribution)

--- a/gssutils/scrapers/ons.py
+++ b/gssutils/scrapers/ons.py
@@ -11,7 +11,7 @@ import requests
 
 import json
 
-ONS_PREFIX = "http://www.ons.gov.uk"
+ONS_PREFIX = "https://www.ons.gov.uk"
 ONS_DOWNLOAD_PREFIX = ONS_PREFIX+"/file?uri="
 
 
@@ -75,9 +75,10 @@ def onshandler_dataset_landing_page(scraper, landing_page):
                          .format(",".join(landing_page["datasets"])))
 
     # Acquire basic metadata from the dataset_landing_page
-    scraper.dataset.title = landing_page["description"]["title"]
+    scraper.dataset.title = landing_page["description"]["title"].strip()
     scraper.dataset.description = landing_page["description"]["metaDescription"]
     scraper.dataset.issued = parse(landing_page["description"]["releaseDate"])
+    scraper.dataset.comment = landing_page["description"]["summary"].strip()
 
     # next release is sometimes blank, so use a conditional
     if landing_page["description"]["nextRelease"] != "":

--- a/gssutils/scrapers/ons.py
+++ b/gssutils/scrapers/ons.py
@@ -77,7 +77,7 @@ def onshandler_dataset_landing_page(scraper, landing_page):
     # Acquire basic metadata from the dataset_landing_page
     scraper.dataset.title = landing_page["description"]["title"].strip()
     scraper.dataset.description = landing_page["description"]["metaDescription"]
-    scraper.dataset.issued = parse(landing_page["description"]["releaseDate"])
+    scraper.dataset.issued = parse(landing_page["description"]["releaseDate"]).date()
     scraper.dataset.comment = landing_page["description"]["summary"].strip()
 
     # next release is sometimes blank, so use a conditional
@@ -125,7 +125,7 @@ def onshandler_dataset_landing_page(scraper, landing_page):
 
             # Distribution object to represent this distribution
             this_distribution = Distribution(scraper)
-            this_distribution.issued = parse(release_date)
+            this_distribution.issued = parse(release_date.strip()).date()
 
             assert 'file' in dl.keys(), "Aborting, expecting dict with 'file' key. Instead " \
                     + "we got: {}.".format(str(dl))


### PR DESCRIPTION
Ok, so I've done a few things here in the sprit of not having to do it again.

1.) Added a scraper for json page_type "dataset_landing_page"
2.) Added a switch so we can create scrapers for different page types if we need to.
3.) Used a try catch so if its not a json page it'll fall back on the older scraper (with a depreciation warning), so we can deploy without breaking the world.

All works, behave passes (behaves? 😄) and it's creating .trig that matches (as far as I can tell) the previous ones.

There is one nasty looking bit where I've having to quick-switch back to html to get the file size. It works but it's a bit fugly, if one of my old team mates doesn't volunteer whatever secret api they're getting those values from in a few days I'll go track it own.

edit - I'm gonna have to write a raft of tests for this aren't I?