### PR TITLE
Clean scrape.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Shared data transformation utilities for GSS data.
 
 #### vcrpy does not overwrite interactions
 
-When running tests with `record-mode=all` e.g.
+When running a test with `record-mode=all` e.g.
 ```shell script
- pipenv run behave -D record_mode=all --tags=-skip -n 'NHS' features/scrape.feature
+ pipenv run behave -D record_mode=all --tags=-skip -n '[Name of test]' features/scrape.feature
 ```
 the scrape.yml sections are not overwritten. Instead, new ones are appended.
 
@@ -16,7 +16,7 @@ the scrape.yml sections are not overwritten. Instead, new ones are appended.
 After running the tests, use the `clean-fixtures.py` script to remove repeated interactions.
 The run the same tests with `record-mode=none` to confirm they all pass.
 ```shell script
- pipenv run behave -D record_mode=none --tags=-skip -n 'NHS' features/scrape.feature
+ pipenv run behave -D record_mode=none --tags=-skip -n '[Name of test]' features/scrape.feature
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 Shared data transformation utilities for GSS data.
 
+### Known issues
+
+#### vcrpy does not overwrite interactions
+
+When running tests with `record-mode=all` e.g.
+```shell script
+ pipenv run behave -D record_mode=all --tags=-skip -n 'NHS' features/scrape.feature
+```
+the scrape.yml sections are not overwritten. Instead, new ones are appended.
+
+**Workaround**:
+After running the tests, use the `clean-fixtures.py` script to remove repeated interactions.
+The run the same tests with `record-mode=none` to confirm they all pass.
+```shell script
+ pipenv run behave -D record_mode=none --tags=-skip -n 'NHS' features/scrape.feature
+```
+
 ---
 
    Copyright 2018 Alex Tucker


### PR DESCRIPTION
### What's this about? 
In merging PR #80 we unintentionally pushed changes to the scrape.yml. This PR cleans those changes 🤞 

Readme now has details on workaround for vcrpy not overweritting interactions.

### How do I review this?
Get the code and... 
`pipenv run behave -D record_mode=none --tags=-skip features/scrape.feature`

This is my output
```
1 feature passed, 0 failed, 0 skipped
31 scenarios passed, 0 failed, 2 skipped
134 steps passed, 0 failed, 8 skipped, 0 undefined
```
(and a lot of errors that I'm told are expected 😁 🧊 )