### PR TITLE
Fixes/issues 82 90

### DIFF
--- a/features/fixtures/seed-for-temporary-scraper.json
+++ b/features/fixtures/seed-for-temporary-scraper.json
@@ -3,5 +3,8 @@
   "description": "I am a description from the metadata seed",
   "dataURL": "https://www.contextures.com/SampleData.zip",
   "publisher": "COGS data testing",
-  "published": "2019-01-01"
+  "published": "2019-01-01",
+  "families": [
+    "Swiss Family Robinson"
+  ]
 }

--- a/gssutils/scrape.py
+++ b/gssutils/scrape.py
@@ -158,7 +158,8 @@ class Scraper:
             raise NotImplementedError(f'No scraper for {self.uri} and insufficient seed metadata passed.')
 
         # Apply overrides to either method of scraping
-        self._override_metadata_where_specified()
+        if self.seed is not None:
+            self._override_metadata_where_specified()
 
         return self
 

--- a/gssutils/scrapers/ons.py
+++ b/gssutils/scrapers/ons.py
@@ -37,7 +37,7 @@ def scrape(scraper, tree):
     except Exception as e:
         raise ValueError("Aborting operation This is not json-able content.") from e
 
-    accepted_page_types = ["dataset_landing_page"]
+    accepted_page_types = ["dataset_landing_page", "static_adhoc"]
     if landing_page["type"] not in accepted_page_types:
         raise ValueError("Aborting operation This page type is not supported.")
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/ONS-OpenData/gss-utils",
     packages=setuptools.find_packages(),
-    setup_requires=['setuptools-git-version'],
+    setup_requires=['better-setuptools-git-version'],
     install_requires=['requests',
                       'python_dateutil',
                       'CacheControl',


### PR DESCRIPTION
Fixes broken tests from recent merges, various:

* Add "static_adhoc" to ONS scraper allowed types to support a legacy test.
* Update vcr fixture for missing url.
* Add a guard for legacy tests calling seed where seed is none.
* Added a families to original seed test (as "families" wasn't a thing back then).

In theory that's everything back to passing, though at least one other person should definitely run the whole suite to make sure.

Run the tests :within a locally cloned gssutils repo
```
pipenv sync
pipenv install -r test-requirements.txt
pipenv run behave -D record_mode=none --tags=-skip
```