### PR TITLE
Issue 94 measure type column

### DIFF
--- a/features/csvw.feature
+++ b/features/csvw.feature
@@ -121,3 +121,35 @@ Feature: Create CSVW metadata
     When I create a CSVW file from the mapping and CSV
     Then the metadata is valid JSON-LD
     And the input format of the csv is recorded as csv
+
+  Scenario: CSVMetadata from mapping with measure type and unit columns
+    Given a CSV file 'observations.csv'
+      | Period          | Flow    | HMRC Reporter Region | HMRC Partner Geography | SITC 4 | Value | Measure Type | Unit          |
+      | quarter/2018-Q1 | exports | EA                   | A                      | 01     | 2430  | net-mass     | kg-thousands  |
+      | quarter/2018-Q1 | exports | EA                   | A                      | 02     | 2     | net-mass     | kg-thousands  |
+      | quarter/2018-Q4 | imports | ZB                   | TR                     | 88     | 10    | gbp-total    | gbp-thousands |
+      | quarter/2018-Q4 | imports | ZB                   | TR                     | 89     | 352   | gbp-total    | gbp-thousands |
+    And a column map
+    """
+    "columns": {
+      "Period": {
+      },
+      "Flow": {
+      },
+      "SITC 4": {
+      },
+      "Value": {
+        "measureRef": "Measure Type",
+        "unitRef": "Unit",
+        "datatype": "integer"
+      }
+    }
+    """
+    And a dataset URI 'http://gss-data.org.uk/data/gss_data/trade/hmrc_rts'
+    When I create a CSVW file from the mapping and CSV
+    Then the metadata is valid JSON-LD
+    And gsscogs/csv2rdf generates RDF
+    And the RDF should pass the Data Cube integrity constraints
+    And the RDF should contain
+    """
+    """

--- a/features/csvw.feature
+++ b/features/csvw.feature
@@ -144,9 +144,16 @@ Feature: Create CSVW metadata
         "dimension": "http://gss-data.org.uk/def/dimension/sitc-4",
         "value": "http://gss-data.org.uk/def/concept/sitc-4/{sitc_4}"
       },
+      "Measure Type": {
+        "dimension": "http://purl.org/linked-data/cube#measureType",
+        "value": "http://gss-data.org.uk/def/measure/{measure_type}",
+        "types": ["net-mass", "gbp-total"]
+      },
+      "Unit": {
+        "attribute": "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure",
+        "value": "http://gss-data.org.uk/def/concept/measurement-units/{unit}"
+      },
       "Value": {
-        "measureRef": "Measure Type",
-        "unitRef": "Unit",
         "datatype": "integer"
       }
     }
@@ -201,10 +208,16 @@ Feature: Create CSVW metadata
           a qb:ComponentSpecification .
 
       <#component/period>
-          qb:dimension sdmx-dimension:refPeriod ;
+          qb:dimension <#dimension/period> ;
           a qb:ComponentSpecification .
 
-      <#component/sitc4>
+      <#dimension/period> a qb:DimensionProperty ;
+          rdfs:label "Period"@en ;
+          qb:codeList <#scheme/period> ;
+          rdfs:range <#class/Period> ;
+          rdfs:subPropertyOf <http://purl.org/linked-data/sdmx/2009/dimension#refPeriod> .
+
+      <#component/sitc-4>
           qb:dimension gss-d:sitc-4 ;
           a qb:ComponentSpecification .
 
@@ -215,60 +228,60 @@ Feature: Create CSVW metadata
       <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts/quarter/2018-Q1/exports/EA/A/01/net-mass>
           gss-d:flow-directions <http://gss-data.org.uk/def/concept/flow-directions/exports> ;
           gss-d:sitc-4 <http://gss-data.org.uk/def/concept/sitc-4/01> ;
-          gss-d:hmrc-partner-geography <http://gss-data.org.uk/def/concept/hmrc-geographies/A> ;
-          gss-d:hmrc-reporter-region <http://gss-data.org.uk/def/concept/hmrc-regions/EA> ;
-          <http://gss-data.org.uk/def/measure/net-mass> 2.43E3 ;
-          qb:dataSet <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts> ;
+          <#dimension/hmrc-partner-geography> <#concept/hmrc-partner-geography/A> ;
+          <#dimension/hmrc-reporter-region> <#concept/hmrc-reporter-region/EA> ;
+          <http://gss-data.org.uk/def/measure/net-mass> 2430 ;
+          qb:dataSet <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts#dataset> ;
           qb:measureType <http://gss-data.org.uk/def/measure/net-mass> ;
           sdmx-attribute:unitMeasure <http://gss-data.org.uk/def/concept/measurement-units/kg-thousands> ;
-          sdmx-dimension:refPeriod <http://reference.data.gov.uk/id/quarter/2018-Q1> ;
+          <#dimension/period> <http://reference.data.gov.uk/id/quarter/2018-Q1> ;
           a qb:Observation .
 
       <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts/quarter/2018-Q1/exports/EA/A/02/net-mass>
           gss-d:flow-directions <http://gss-data.org.uk/def/concept/flow-directions/exports> ;
           gss-d:sitc-4 <http://gss-data.org.uk/def/concept/sitc-4/02> ;
-          gss-d:hmrc-partner-geography <http://gss-data.org.uk/def/concept/hmrc-geographies/A> ;
-          gss-d:hmrc-reporter-region <http://gss-data.org.uk/def/concept/hmrc-regions/EA> ;
-          <http://gss-data.org.uk/def/measure/net-mass> 2.0E0 ;
-          qb:dataSet <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts> ;
+          <#dimension/hmrc-partner-geography> <#concept/hmrc-partner-geography/A> ;
+          <#dimension/hmrc-reporter-region> <#concept/hmrc-reporter-region/EA> ;
+          <http://gss-data.org.uk/def/measure/net-mass> 2 ;
+          qb:dataSet <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts#dataset> ;
           qb:measureType <http://gss-data.org.uk/def/measure/net-mass> ;
           sdmx-attribute:unitMeasure <http://gss-data.org.uk/def/concept/measurement-units/kg-thousands> ;
-          sdmx-dimension:refPeriod <http://reference.data.gov.uk/id/quarter/2018-Q1> ;
+          <#dimension/period> <http://reference.data.gov.uk/id/quarter/2018-Q1> ;
           a qb:Observation .
 
       <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts/quarter/2018-Q4/imports/ZB/TR/88/gbp-total>
           gss-d:flow-directions <http://gss-data.org.uk/def/concept/flow-directions/imports> ;
           gss-d:sitc-4 <http://gss-data.org.uk/def/concept/sitc-4/88> ;
-          gss-d:hmrc-partner-geography <http://gss-data.org.uk/def/concept/hmrc-geographies/TR> ;
-          gss-d:hmrc-reporter-region <http://gss-data.org.uk/def/concept/hmrc-regions/ZB> ;
-          <http://gss-data.org.uk/def/measure/gbp-total> 1.0E1 ;
-          qb:dataSet <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts> ;
+          <#dimension/hmrc-partner-geography> <#concept/hmrc-partner-geography/TR> ;
+          <#dimension/hmrc-reporter-region> <#concept/hmrc-reporter-region/ZB> ;
+          <http://gss-data.org.uk/def/measure/gbp-total> 10 ;
+          qb:dataSet <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts#dataset> ;
           qb:measureType <http://gss-data.org.uk/def/measure/gbp-total> ;
           sdmx-attribute:unitMeasure <http://gss-data.org.uk/def/concept/measurement-units/gbp-thousands> ;
-          sdmx-dimension:refPeriod <http://reference.data.gov.uk/id/quarter/2018-Q4> ;
+          <#dimension/period> <http://reference.data.gov.uk/id/quarter/2018-Q4> ;
           a qb:Observation .
 
       <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts/quarter/2018-Q4/imports/ZB/TR/89/gbp-total>
           gss-d:flow-directions <http://gss-data.org.uk/def/concept/flow-directions/imports> ;
           gss-d:sitc-4 <http://gss-data.org.uk/def/concept/sitc-4/89> ;
-          gss-d:hmrc-partner-geography <http://gss-data.org.uk/def/concept/hmrc-geographies/TR> ;
-          gss-d:hmrc-reporter-region <http://gss-data.org.uk/def/concept/hmrc-regions/ZB> ;
-          <http://gss-data.org.uk/def/measure/gbp-total> 3.52E2 ;
-          qb:dataSet <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts> ;
+          <#dimension/hmrc-partner-geography> <#concept/hmrc-partner-geography/TR> ;
+          <#dimension/hmrc-reporter-region> <#concept/hmrc-reporter-region/ZB> ;
+          <http://gss-data.org.uk/def/measure/gbp-total> 352 ;
+          qb:dataSet <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts#dataset> ;
           qb:measureType <http://gss-data.org.uk/def/measure/gbp-total> ;
           sdmx-attribute:unitMeasure <http://gss-data.org.uk/def/concept/measurement-units/gbp-thousands> ;
-          sdmx-dimension:refPeriod <http://reference.data.gov.uk/id/quarter/2018-Q4> ;
+          <#dimension/period> <http://reference.data.gov.uk/id/quarter/2018-Q4> ;
           a qb:Observation .
 
       <#structure>
           qb:component <#component/flow>,
-                       <#component/gbp_total>,
-                       <#component/hmrc_partner_geography>,
-                       <#component/hmrc_reporter_region>,
-                       <#component/measure_type>,
-                       <#component/net_mass>,
+                       <#component/gbp-total>,
+                       <#component/hmrc-partner-geography>,
+                       <#component/hmrc-reporter-region>,
+                       <#component/measure-type>,
+                       <#component/net-mass>,
                        <#component/period>,
-                       <#component/sitc4>,
+                       <#component/sitc-4>,
                        <#component/unit> ;
           a qb:DataStructureDefinition .
     """

--- a/features/csvw.feature
+++ b/features/csvw.feature
@@ -124,17 +124,18 @@ Feature: Create CSVW metadata
 
   Scenario: CSVMetadata from mapping with measure type and unit columns
     Given a CSV file 'observations.csv'
-      | Period          | Flow    | HMRC Reporter Region | HMRC Partner Geography | SITC 4 | Value | Measure Type | Unit          |
-      | quarter/2018-Q1 | exports | EA                   | A                      | 01     | 2430  | net-mass     | kg-thousands  |
-      | quarter/2018-Q1 | exports | EA                   | A                      | 02     | 2     | net-mass     | kg-thousands  |
-      | quarter/2018-Q4 | imports | ZB                   | TR                     | 88     | 10    | gbp-total    | gbp-thousands |
-      | quarter/2018-Q4 | imports | ZB                   | TR                     | 89     | 352   | gbp-total    | gbp-thousands |
+      | Period  | Flow    | HMRC Reporter Region | HMRC Partner Geography | SITC 4 | Value | Measure Type | Unit          |
+      | 2018-Q1 | exports | EA                   | A                      | 01     | 2430  | net-mass     | kg-thousands  |
+      | 2018-Q1 | exports | EA                   | A                      | 02     | 2     | net-mass     | kg-thousands  |
+      | 2018-Q4 | imports | ZB                   | TR                     | 88     | 10    | total        | gbp-thousands |
+      | 2018-Q4 | imports | ZB                   | TR                     | 89     | 352   | total        | gbp-thousands |
     And a column map
     """
     {
       "Period": {
+        "label": "Quarter",
         "parent": "http://purl.org/linked-data/sdmx/2009/dimension#refPeriod",
-        "value": "http://reference.data.gov.uk/id/{+period}"
+        "value": "http://reference.data.gov.uk/id/quarter/{period}"
       },
       "Flow": {
         "dimension": "http://gss-data.org.uk/def/dimension/flow-directions",
@@ -147,7 +148,7 @@ Feature: Create CSVW metadata
       "Measure Type": {
         "dimension": "http://purl.org/linked-data/cube#measureType",
         "value": "http://gss-data.org.uk/def/measure/{measure_type}",
-        "types": ["net-mass", "gbp-total"]
+        "types": ["net-mass", "total"]
       },
       "Unit": {
         "attribute": "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure",
@@ -187,8 +188,8 @@ Feature: Create CSVW metadata
           qb:dimension gss-d:flow-directions ;
           a qb:ComponentSpecification .
 
-      <#component/gbp-total>
-          qb:measure <http://gss-data.org.uk/def/measure/gbp-total> ;
+      <#component/total>
+          qb:measure <http://gss-data.org.uk/def/measure/total> ;
           a qb:ComponentSpecification .
 
       <#component/hmrc-partner-geography>
@@ -212,7 +213,7 @@ Feature: Create CSVW metadata
           a qb:ComponentSpecification .
 
       <#dimension/period> a qb:DimensionProperty ;
-          rdfs:label "Period"@en ;
+          rdfs:label "Quarter"@en ;
           qb:codeList <#scheme/period> ;
           rdfs:range <#class/Period> ;
           rdfs:subPropertyOf <http://purl.org/linked-data/sdmx/2009/dimension#refPeriod> .
@@ -225,7 +226,7 @@ Feature: Create CSVW metadata
           qb:attribute sdmx-attribute:unitMeasure ;
           a qb:ComponentSpecification .
 
-      <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts/quarter/2018-Q1/exports/EA/A/01/net-mass>
+      <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts/2018-Q1/exports/EA/A/01/net-mass>
           gss-d:flow-directions <http://gss-data.org.uk/def/concept/flow-directions/exports> ;
           gss-d:sitc-4 <http://gss-data.org.uk/def/concept/sitc-4/01> ;
           <#dimension/hmrc-partner-geography> <#concept/hmrc-partner-geography/A> ;
@@ -237,7 +238,7 @@ Feature: Create CSVW metadata
           <#dimension/period> <http://reference.data.gov.uk/id/quarter/2018-Q1> ;
           a qb:Observation .
 
-      <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts/quarter/2018-Q1/exports/EA/A/02/net-mass>
+      <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts/2018-Q1/exports/EA/A/02/net-mass>
           gss-d:flow-directions <http://gss-data.org.uk/def/concept/flow-directions/exports> ;
           gss-d:sitc-4 <http://gss-data.org.uk/def/concept/sitc-4/02> ;
           <#dimension/hmrc-partner-geography> <#concept/hmrc-partner-geography/A> ;
@@ -249,33 +250,33 @@ Feature: Create CSVW metadata
           <#dimension/period> <http://reference.data.gov.uk/id/quarter/2018-Q1> ;
           a qb:Observation .
 
-      <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts/quarter/2018-Q4/imports/ZB/TR/88/gbp-total>
+      <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts/2018-Q4/imports/ZB/TR/88/total>
           gss-d:flow-directions <http://gss-data.org.uk/def/concept/flow-directions/imports> ;
           gss-d:sitc-4 <http://gss-data.org.uk/def/concept/sitc-4/88> ;
           <#dimension/hmrc-partner-geography> <#concept/hmrc-partner-geography/TR> ;
           <#dimension/hmrc-reporter-region> <#concept/hmrc-reporter-region/ZB> ;
-          <http://gss-data.org.uk/def/measure/gbp-total> 10 ;
+          <http://gss-data.org.uk/def/measure/total> 10 ;
           qb:dataSet <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts#dataset> ;
-          qb:measureType <http://gss-data.org.uk/def/measure/gbp-total> ;
+          qb:measureType <http://gss-data.org.uk/def/measure/total> ;
           sdmx-attribute:unitMeasure <http://gss-data.org.uk/def/concept/measurement-units/gbp-thousands> ;
           <#dimension/period> <http://reference.data.gov.uk/id/quarter/2018-Q4> ;
           a qb:Observation .
 
-      <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts/quarter/2018-Q4/imports/ZB/TR/89/gbp-total>
+      <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts/2018-Q4/imports/ZB/TR/89/total>
           gss-d:flow-directions <http://gss-data.org.uk/def/concept/flow-directions/imports> ;
           gss-d:sitc-4 <http://gss-data.org.uk/def/concept/sitc-4/89> ;
           <#dimension/hmrc-partner-geography> <#concept/hmrc-partner-geography/TR> ;
           <#dimension/hmrc-reporter-region> <#concept/hmrc-reporter-region/ZB> ;
-          <http://gss-data.org.uk/def/measure/gbp-total> 352 ;
+          <http://gss-data.org.uk/def/measure/total> 352 ;
           qb:dataSet <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts#dataset> ;
-          qb:measureType <http://gss-data.org.uk/def/measure/gbp-total> ;
+          qb:measureType <http://gss-data.org.uk/def/measure/total> ;
           sdmx-attribute:unitMeasure <http://gss-data.org.uk/def/concept/measurement-units/gbp-thousands> ;
           <#dimension/period> <http://reference.data.gov.uk/id/quarter/2018-Q4> ;
           a qb:Observation .
 
       <#structure>
           qb:component <#component/flow>,
-                       <#component/gbp-total>,
+                       <#component/total>,
                        <#component/hmrc-partner-geography>,
                        <#component/hmrc-reporter-region>,
                        <#component/measure-type>,

--- a/features/csvw.feature
+++ b/features/csvw.feature
@@ -131,12 +131,18 @@ Feature: Create CSVW metadata
       | quarter/2018-Q4 | imports | ZB                   | TR                     | 89     | 352   | gbp-total    | gbp-thousands |
     And a column map
     """
-    "columns": {
+    {
       "Period": {
+        "parent": "http://purl.org/linked-data/sdmx/2009/dimension#refPeriod",
+        "value": "http://reference.data.gov.uk/id/{+period}"
       },
       "Flow": {
+        "dimension": "http://gss-data.org.uk/def/dimension/flow-directions",
+        "value": "http://gss-data.org.uk/def/concept/flow-directions/{flow}"
       },
       "SITC 4": {
+        "dimension": "http://gss-data.org.uk/def/dimension/sitc-4",
+        "value": "http://gss-data.org.uk/def/concept/sitc-4/{sitc_4}"
       },
       "Value": {
         "measureRef": "Measure Type",
@@ -152,4 +158,117 @@ Feature: Create CSVW metadata
     And the RDF should pass the Data Cube integrity constraints
     And the RDF should contain
     """
+      @base <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts> .
+      @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+      @prefix owl: <http://www.w3.org/2002/07/owl#> .
+      @prefix void: <http://rdfs.org/ns/void#> .
+      @prefix dcterms: <http://purl.org/dc/terms/> .
+      @prefix dcat: <http://www.w3.org/ns/dcat#> .
+      @prefix sdmx-dimension: <http://purl.org/linked-data/sdmx/2009/dimension#> .
+      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+      @prefix sdmx-attribute: <http://purl.org/linked-data/sdmx/2009/attribute#> .
+      @prefix qb: <http://purl.org/linked-data/cube#> .
+      @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+      @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+      @prefix sdmx-concept: <http://purl.org/linked-data/sdmx/2009/concept#> .
+      @prefix gss-d: <http://gss-data.org.uk/def/dimension/> .
+
+      <#dataset> a qb:DataSet ;
+        qb:structure <#structure> .
+
+      <#component/flow>
+          qb:dimension gss-d:flow-directions ;
+          a qb:ComponentSpecification .
+
+      <#component/gbp-total>
+          qb:measure <http://gss-data.org.uk/def/measure/gbp-total> ;
+          a qb:ComponentSpecification .
+
+      <#component/hmrc-partner-geography>
+          qb:dimension <#dimension/hmrc-partner-geography> ;
+          a qb:ComponentSpecification .
+
+      <#component/hmrc-reporter-region>
+          qb:dimension <#dimension/hmrc-reporter-region> ;
+          a qb:ComponentSpecification .
+
+      <#component/measure-type>
+          qb:dimension qb:measureType ;
+          a qb:ComponentSpecification .
+
+      <#component/net-mass>
+          qb:measure <http://gss-data.org.uk/def/measure/net-mass> ;
+          a qb:ComponentSpecification .
+
+      <#component/period>
+          qb:dimension sdmx-dimension:refPeriod ;
+          a qb:ComponentSpecification .
+
+      <#component/sitc4>
+          qb:dimension gss-d:sitc-4 ;
+          a qb:ComponentSpecification .
+
+      <#component/unit>
+          qb:attribute sdmx-attribute:unitMeasure ;
+          a qb:ComponentSpecification .
+
+      <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts/quarter/2018-Q1/exports/EA/A/01/net-mass>
+          gss-d:flow-directions <http://gss-data.org.uk/def/concept/flow-directions/exports> ;
+          gss-d:sitc-4 <http://gss-data.org.uk/def/concept/sitc-4/01> ;
+          gss-d:hmrc-partner-geography <http://gss-data.org.uk/def/concept/hmrc-geographies/A> ;
+          gss-d:hmrc-reporter-region <http://gss-data.org.uk/def/concept/hmrc-regions/EA> ;
+          <http://gss-data.org.uk/def/measure/net-mass> 2.43E3 ;
+          qb:dataSet <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts> ;
+          qb:measureType <http://gss-data.org.uk/def/measure/net-mass> ;
+          sdmx-attribute:unitMeasure <http://gss-data.org.uk/def/concept/measurement-units/kg-thousands> ;
+          sdmx-dimension:refPeriod <http://reference.data.gov.uk/id/quarter/2018-Q1> ;
+          a qb:Observation .
+
+      <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts/quarter/2018-Q1/exports/EA/A/02/net-mass>
+          gss-d:flow-directions <http://gss-data.org.uk/def/concept/flow-directions/exports> ;
+          gss-d:sitc-4 <http://gss-data.org.uk/def/concept/sitc-4/02> ;
+          gss-d:hmrc-partner-geography <http://gss-data.org.uk/def/concept/hmrc-geographies/A> ;
+          gss-d:hmrc-reporter-region <http://gss-data.org.uk/def/concept/hmrc-regions/EA> ;
+          <http://gss-data.org.uk/def/measure/net-mass> 2.0E0 ;
+          qb:dataSet <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts> ;
+          qb:measureType <http://gss-data.org.uk/def/measure/net-mass> ;
+          sdmx-attribute:unitMeasure <http://gss-data.org.uk/def/concept/measurement-units/kg-thousands> ;
+          sdmx-dimension:refPeriod <http://reference.data.gov.uk/id/quarter/2018-Q1> ;
+          a qb:Observation .
+
+      <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts/quarter/2018-Q4/imports/ZB/TR/88/gbp-total>
+          gss-d:flow-directions <http://gss-data.org.uk/def/concept/flow-directions/imports> ;
+          gss-d:sitc-4 <http://gss-data.org.uk/def/concept/sitc-4/88> ;
+          gss-d:hmrc-partner-geography <http://gss-data.org.uk/def/concept/hmrc-geographies/TR> ;
+          gss-d:hmrc-reporter-region <http://gss-data.org.uk/def/concept/hmrc-regions/ZB> ;
+          <http://gss-data.org.uk/def/measure/gbp-total> 1.0E1 ;
+          qb:dataSet <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts> ;
+          qb:measureType <http://gss-data.org.uk/def/measure/gbp-total> ;
+          sdmx-attribute:unitMeasure <http://gss-data.org.uk/def/concept/measurement-units/gbp-thousands> ;
+          sdmx-dimension:refPeriod <http://reference.data.gov.uk/id/quarter/2018-Q4> ;
+          a qb:Observation .
+
+      <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts/quarter/2018-Q4/imports/ZB/TR/89/gbp-total>
+          gss-d:flow-directions <http://gss-data.org.uk/def/concept/flow-directions/imports> ;
+          gss-d:sitc-4 <http://gss-data.org.uk/def/concept/sitc-4/89> ;
+          gss-d:hmrc-partner-geography <http://gss-data.org.uk/def/concept/hmrc-geographies/TR> ;
+          gss-d:hmrc-reporter-region <http://gss-data.org.uk/def/concept/hmrc-regions/ZB> ;
+          <http://gss-data.org.uk/def/measure/gbp-total> 3.52E2 ;
+          qb:dataSet <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts> ;
+          qb:measureType <http://gss-data.org.uk/def/measure/gbp-total> ;
+          sdmx-attribute:unitMeasure <http://gss-data.org.uk/def/concept/measurement-units/gbp-thousands> ;
+          sdmx-dimension:refPeriod <http://reference.data.gov.uk/id/quarter/2018-Q4> ;
+          a qb:Observation .
+
+      <#structure>
+          qb:component <#component/flow>,
+                       <#component/gbp_total>,
+                       <#component/hmrc_partner_geography>,
+                       <#component/hmrc_reporter_region>,
+                       <#component/measure_type>,
+                       <#component/net_mass>,
+                       <#component/period>,
+                       <#component/sitc4>,
+                       <#component/unit> ;
+          a qb:DataStructureDefinition .
     """

--- a/features/steps/csvw.py
+++ b/features/steps/csvw.py
@@ -308,3 +308,8 @@ def step_impl(context, files):
         metadata_path = csv_path.with_suffix('.csv-metadata.json')
         with csv_path.open('r') as csv_file, metadata_path.open('r') as metadata_file:
             context.extra_data.append(run_csv2rdf(csv_path.name, metadata_file.name, csv_file, metadata_file))
+
+
+@step("a column map")
+def step_impl(context):
+    raise NotImplementedError(u'STEP: And a column map')

--- a/features/steps/csvw.py
+++ b/features/steps/csvw.py
@@ -312,4 +312,6 @@ def step_impl(context, files):
 
 @step("a column map")
 def step_impl(context):
-    raise NotImplementedError(u'STEP: And a column map')
+    mapping = {'transform': {'columns': json.loads(context.text)}}
+    context.json_io = StringIO()
+    json.dump(mapping, context.json_io)

--- a/gssutils/csvw/mapping.py
+++ b/gssutils/csvw/mapping.py
@@ -247,7 +247,6 @@ class CSVWMapping:
                                 rdfs_range=Resource(at_id=URI("http://purl.org/linked-data/cube#MeasureProperty"))
                             )
                         ),
-                        # ToDo: figure out the measures used, either from CSV column values, or declared in mapping.
                         MeasureComponent(
                             at_id=self.join_dataset_uri(f"#component/{pathify(name)}"),
                             qb_componentProperty=Resource(at_id=obj["measure"]),

--- a/gssutils/transform/cubes.py
+++ b/gssutils/transform/cubes.py
@@ -24,7 +24,7 @@ class Cubes:
 
         # Where we don't have a mapping field, add one to avoid iteration errors later
         if "columns" not in self.info["transform"].keys():
-            self.info["transform"]["columns"] = []
+            self.info["transform"]["columns"] = {}
 
         self.destination_folder = Path(destination_path)
         self.destination_folder.mkdir(exist_ok=True, parents=True)


### PR DESCRIPTION
Implement the "measure type" column approach by declaring a map for the measure type (and unit), e.g.:

```
      "Measure Type": {
        "dimension": "http://purl.org/linked-data/cube#measureType",
        "value": "http://gss-data.org.uk/def/measure/{measure_type}",
        "types": ["net-mass", "gbp-total"]
      },
      "Unit": {
        "attribute": "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure",
        "value": "http://gss-data.org.uk/def/concept/measurement-units/{unit}"
      },
      "Value": {
        "datatype": "integer"
      }
```

Note that

1) the `"types"` are provided so that we don't have to iterate through the whole CSV file to find the unique values for the measure type;
2) the `"Value"` column is identified as not having a `"measure"` or `"unit"` declaration;
3) the `"Value"` column can have only one datatype using this approach.