### PR TITLE
Allow setting Codelist Location URI

### DIFF
--- a/features/csvw.feature
+++ b/features/csvw.feature
@@ -108,7 +108,7 @@ Feature: Create CSVW metadata
 
       <#dimension/area-code> a qb:DimensionProperty ;
         rdfs:label "Area"@en ;
-        qb:codeList <#scheme/area-code> ;
+        qb:codeList <http://statistics.data.gov.uk/id/statistical-geography/some-code-list> ;
         rdfs:range <#class/AreaCode> ;
         rdfs:subPropertyOf <http://purl.org/linked-data/sdmx/2009/dimension#refArea> .
 

--- a/features/fixtures/notifications.json
+++ b/features/fixtures/notifications.json
@@ -14,7 +14,8 @@
       "Area Code": {
         "label": "Area",
         "parent": "http://purl.org/linked-data/sdmx/2009/dimension#refArea",
-        "value": "http://statistics.data.gov.uk/id/statistical-geography/{area_code}"
+        "value": "http://statistics.data.gov.uk/id/statistical-geography/{area_code}",
+        "codelist": "http://statistics.data.gov.uk/id/statistical-geography/some-code-list"
       },
       "Value": {
         "unit": "http://gss-data.org.uk/def/concept/measurement-units/deaths",

--- a/gssutils/csvw/mapping.py
+++ b/gssutils/csvw/mapping.py
@@ -181,7 +181,7 @@ class CSVWMapping:
                                 at_id=self.join_dataset_uri(f"#class/{CSVWMapping.classify(name)}")
                             ),
                             qb_codeList=Resource(
-                                at_id=self.join_dataset_uri(f"#scheme/{pathify(name)}")
+                                at_id=obj.get("codelist", self.join_dataset_uri(f"#scheme/{pathify(name)}"))
                             ),
                             rdfs_label=label,
                             rdfs_comment=description,
@@ -210,7 +210,7 @@ class CSVWMapping:
                                 at_id=self.join_dataset_uri(f"#class/{CSVWMapping.classify(name)}")
                             ),
                             qb_codeList=Resource(
-                                at_id=self.join_dataset_uri(f"#scheme/{pathify(name)}")
+                                at_id=obj.get("codelist", self.join_dataset_uri(f"#scheme/{pathify(name)}"))
                             ),
                             rdfs_label=label,
                             rdfs_comment=description,


### PR DESCRIPTION
SDMX/qb Dimensions must have codelists associated with the dimension property. We currently have no way of specifying where a dimension's codelist exists if it isn't a codelist local to the dataset.

This change is required to ensure we cabn pass the [pmd4/dsd.Dimensions Must Have Concepts In Code List](https://github.com/GSS-Cogs/gdp-sparql-tests/blob/c42c550197b1bc585fe667c4ec4c2e55c1f1784e/tests/pmd/pmd4/dsd/SELECT_DimensionsMustHaveConceptsInCodeList.sparql) SPARQL test.

https://github.com/GSS-Cogs/pmd-jenkins-library/issues/37