### PR TITLE
Allow undefined codelists for dimensions

### DIFF
--- a/features/csvw.feature
+++ b/features/csvw.feature
@@ -135,7 +135,8 @@ Feature: Create CSVW metadata
       "Period": {
         "label": "Quarter",
         "parent": "http://purl.org/linked-data/sdmx/2009/dimension#refPeriod",
-        "value": "http://reference.data.gov.uk/id/quarter/{period}"
+        "value": "http://reference.data.gov.uk/id/quarter/{period}",
+        "codelist": false
       },
       "Flow": {
         "dimension": "http://gss-data.org.uk/def/dimension/flow-directions",
@@ -214,7 +215,6 @@ Feature: Create CSVW metadata
 
       <#dimension/period> a qb:DimensionProperty ;
           rdfs:label "Quarter"@en ;
-          qb:codeList <#scheme/period> ;
           rdfs:range <#class/Period> ;
           rdfs:subPropertyOf <http://purl.org/linked-data/sdmx/2009/dimension#refPeriod> .
 


### PR DESCRIPTION
This code change is to ensure that we can avoid setting codelists against dimensions where we there are continous ranges which simply cannot be represented by codelists.

See https://github.com/GSS-Cogs/pmd-jenkins-library/issues/37#issuecomment-754085987 for brief discussion.