### PR TITLE
Fix Codelist URI in Multi-dataframe Datasets

### DIFF
--- a/features/csvw.feature
+++ b/features/csvw.feature
@@ -286,3 +286,48 @@ Feature: Create CSVW metadata
                        <#component/unit> ;
           a qb:DataStructureDefinition .
     """
+
+Scenario: Codelist URIS are built relative to the dataset root directory URI - not the dataframe's URI.
+  e.g. `http://gss-data.org.uk/data/gss_data/trade/hmrc_rts#scheme/flow` instead of the previously generated URI
+       `http://gss-data.org.uk/data/gss_data/trade/hmrc_rts/first_dataframe#scheme/flow`
+  # N.B. this implicitly tests `CSVWMapping.get_dataset_root_uri`
+    Given a CSV file 'observations.csv'
+      | Flow    | Value | Measure Type | Unit          |
+      | exports | 2430  | net-mass     | kg-thousands  |
+    And a column map
+    """
+    {
+      "Flow": {
+        "parent": "http://gss-data.org.uk/def/dimension/flow-directions",
+        "value": "http://gss-data.org.uk/data/gss_data/trade/hmrc_rts#concept/flow/{flow}"
+      },
+      "Measure Type": {
+        "dimension": "http://purl.org/linked-data/cube#measureType",
+        "value": "http://gss-data.org.uk/def/measure/{measure_type}",
+        "types": ["net-mass", "total"]
+      },
+      "Unit": {
+        "attribute": "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure",
+        "value": "http://gss-data.org.uk/def/concept/measurement-units/{unit}"
+      },
+      "Value": {
+        "datatype": "integer"
+      }
+    }
+    """
+    And a dataset URI 'http://gss-data.org.uk/data/gss_data/trade/hmrc_rts/first_dataframe'
+    When I create a CSVW file from the mapping and CSV
+    Then the metadata is valid JSON-LD
+    And gsscogs/csv2rdf generates RDF
+    And the RDF should pass the Data Cube integrity constraints
+    And the RDF should contain
+    """
+      @base <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts/first_dataframe> .
+      @prefix qb: <http://purl.org/linked-data/cube#> .
+
+      <#dimension/flow> a qb:DimensionProperty ;
+          qb:codeList <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts#scheme/flow>.
+
+      <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts/first_dataframe/exports/net-mass>
+          <#dimension/flow> <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts#concept/flow/exports>.
+    """

--- a/gssutils/csvw/mapping.py
+++ b/gssutils/csvw/mapping.py
@@ -6,6 +6,7 @@ from io import TextIOBase
 from pathlib import Path
 from typing import List, Optional, Dict, TextIO, Any, Set, Union
 from urllib.parse import urljoin
+import re
 
 from uritemplate import variables, URITemplate
 
@@ -51,16 +52,37 @@ class CSVWMapping:
     def classify(column_header: str):
         return ''.join(part.capitalize() for part in pathify(column_header).split('-'))
 
-    def join_dataset_uri(self, relative: str):
+    def get_dataset_root_uri(self) -> Optional[str]:
+        f"""
+        Where datasets have multiple distinct dataframes, `self._dataset_uri` is of the form
+            http://gss-data.org.uk/data/gss_data/<family_path>/<dataset_root_path>/<dataset_path>
+            
+        Codelists are defined at the `dataset_root_path` level, so we need to be able to create URIs relative to
+            http://gss-data.org.uk/data/gss_data/<family_path>/<dataset_root_path>
+            
+        This function helps extract the URI up to the `dataset_root_path` fragment by removing any `dataset_path` 
+        fragment from `self._dataset_uri`.
+        """
+        if self._dataset_uri is None:
+            return None
+        matches: re.Match = re.match("^(.+)/gss_data/([^/]+)/([^/]+).*$", self._dataset_uri, re.RegexFlag.IGNORECASE)
+        base_uri = f"{matches.group(1)}/gss_data"
+        family_path = matches.group(2)
+        dataset_root_path = matches.group(3)
+        return f"{base_uri}/{family_path}/{dataset_root_path}"
+
+    def join_dataset_uri(self, relative: str, use_true_dataset_root: bool = False):
         # treat the dataset URI as an entity that when joined with a fragment, just adds
         # the fragment, but when joined with a relative path, turns the dataset URI into a container
         # by adding a / to the end before adding the relative path
-        if self._dataset_uri is None:
+        root_uri = self.get_dataset_root_uri() if use_true_dataset_root else self._dataset_uri
+
+        if root_uri is None:
             return URI(relative)
         elif relative.startswith('#'):
-            return URI(urljoin(self._dataset_uri, relative, allow_fragments=True))
+            return URI(urljoin(root_uri, relative, allow_fragments=True))
         else:
-            return URI(urljoin(self._dataset_uri + '/', relative, allow_fragments=True))
+            return URI(urljoin(root_uri + '/', relative, allow_fragments=True))
 
     def set_csv(self, csv_filename: URI):
 
@@ -125,7 +147,8 @@ class CSVWMapping:
 
     def _as_csvw_object(self):
         def get_conventional_local_codelist_uri(column_name: str) -> Resource:
-            return Resource(at_id=self.join_dataset_uri(f"#scheme/{pathify(column_name)}"))
+            codelist_uri = self.join_dataset_uri(f"#scheme/{pathify(column_name)}", use_true_dataset_root=True)
+            return Resource(at_id=codelist_uri)
 
         def get_maybe_codelist_for_col(column_config: object, column_name: str) -> Optional[Resource]:
             if "codelist" in column_config:


### PR DESCRIPTION
Where a Dataset has multiple dataframes, gss-utils was previously incorrectly specifying the URI of codelists as relative to each dataframe, e.g. `http://gss-data.org.uk/data/gss_data/trade/hmrc_rts/first_dataframe#scheme/flow`. This PR corrects this so that the URIs are relative to the dataset e.g. `http://gss-data.org.uk/data/gss_data/trade/hmrc_rts#scheme/flow`.

Completed as part of https://github.com/GSS-Cogs/pmd-jenkins-library/issues/37