### PR TITLE
Fixing bug where `value` URI is ignored

### DIFF
--- a/features/csvw.feature
+++ b/features/csvw.feature
@@ -333,7 +333,6 @@ Scenario: Codelist URIS are built relative to the dataset root directory URI - n
     """
 
 Scenario: Ensure column definition `value` field is respected when `parent` is not specified.
-  # N.B. this implicitly tests `CSVWMapping.get_dataset_root_uri`
     Given a CSV file 'observations.csv'
       | Implicit Flow | Explicit Flow | Undefined Flow | Value | Measure Type | Unit          |
       | exports       | exports       | exports        | 2430  | net-mass     | kg-thousands  |

--- a/features/csvw.feature
+++ b/features/csvw.feature
@@ -331,3 +331,60 @@ Scenario: Codelist URIS are built relative to the dataset root directory URI - n
       <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts/first_dataframe/exports/net-mass>
           <#dimension/flow> <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts#concept/flow/exports>.
     """
+
+Scenario: Ensure column definition `value` field is respected when `parent` is not specified.
+  # N.B. this implicitly tests `CSVWMapping.get_dataset_root_uri`
+    Given a CSV file 'observations.csv'
+      | Implicit Flow | Explicit Flow | Undefined Flow | Value | Measure Type | Unit          |
+      | exports       | exports       | exports        | 2430  | net-mass     | kg-thousands  |
+    And a column map
+    """
+    {
+      "Implicit Flow": {
+        "description": "The flow, don't ya know?"
+      },
+      "Explicit Flow": {
+        "description": "The flow, don't ya know?",
+        "value": "http://hg2g.is.cool#concept/flow/{explicit_flow}",
+        "codelist": "http://hg2g.is.cool#scheme/flow"
+      },
+      "Measure Type": {
+        "dimension": "http://purl.org/linked-data/cube#measureType",
+        "value": "http://gss-data.org.uk/def/measure/{measure_type}",
+        "types": ["net-mass", "total"]
+      },
+      "Unit": {
+        "attribute": "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure",
+        "value": "http://gss-data.org.uk/def/concept/measurement-units/{unit}"
+      },
+      "Value": {
+        "datatype": "integer"
+      }
+    }
+    """
+    And a dataset URI 'http://gss-data.org.uk/data/gss_data/trade/hmrc_rts'
+    When I create a CSVW file from the mapping and CSV
+    Then the metadata is valid JSON-LD
+    And gsscogs/csv2rdf generates RDF
+    And the RDF should pass the Data Cube integrity constraints
+    And the RDF should contain
+    """
+      @base <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts> .
+      @prefix qb: <http://purl.org/linked-data/cube#> .
+
+      <#dimension/implicit-flow> a qb:DimensionProperty ;
+          qb:codeList <#scheme/implicit-flow>.
+
+      <#dimension/explicit-flow> a qb:DimensionProperty ;
+          qb:codeList <http://hg2g.is.cool#scheme/flow>.
+
+      <#dimension/undefined-flow> a qb:DimensionProperty ;
+          qb:codeList <#scheme/undefined-flow>.
+
+
+      <http://gss-data.org.uk/data/gss_data/trade/hmrc_rts/exports/exports/exports/net-mass>
+          <#dimension/implicit-flow> <#concept/implicit-flow/exports>;
+          <#dimension/explicit-flow> <http://hg2g.is.cool#concept/flow/exports>;
+          <#dimension/undefined-flow> <#concept/undefined-flow/exports>
+          .
+    """

--- a/gssutils/csvw/mapping.py
+++ b/gssutils/csvw/mapping.py
@@ -179,7 +179,7 @@ class CSVWMapping:
             # Codelist should exist. Convention dictates it should be a local codelist.
             return get_conventional_local_codelist_scheme_uri(column_name)
 
-        def get_convential_local_codelist_concept_uri_template(column_name: str) -> URI:
+        def get_conventional_local_codelist_concept_uri_template(column_name: str) -> URI:
             return self.join_dataset_uri(f"#concept/{pathify(column_name)}/{{{self._columns[column_name].name}}}",
                                          use_true_dataset_root=True)
 
@@ -187,7 +187,7 @@ class CSVWMapping:
             if "value" in column_def:
                 return URI(column_def["value"])
 
-            return get_convential_local_codelist_concept_uri_template(column_name)
+            return get_conventional_local_codelist_concept_uri_template(column_name)
 
         # Look to see whether the measure type has its own column
         for map_name, map_obj in self._mapping.items():
@@ -354,7 +354,7 @@ class CSVWMapping:
                 self._keys.append(self._columns[name].name)
                 self._columns[name] = self._columns[name]._replace(
                     propertyUrl=self.join_dataset_uri(f"#dimension/{pathify(name)}"),
-                    valueUrl=get_convential_local_codelist_concept_uri_template(name)
+                    valueUrl=get_conventional_local_codelist_concept_uri_template(name)
                 )
                 self._components.append(DimensionComponent(
                     at_id=self.join_dataset_uri(f"#component/{pathify(name)}"),

--- a/gssutils/csvw/mapping.py
+++ b/gssutils/csvw/mapping.py
@@ -163,7 +163,7 @@ class CSVWMapping:
             logging.error(f"Unknown prefixes used: {used_prefixes.difference(prefix_map.keys())}")
 
     def _as_csvw_object(self):
-        def get_conventional_local_codelist_uri(column_name: str) -> Resource:
+        def get_conventional_local_codelist_scheme_uri(column_name: str) -> Resource:
             codelist_uri = self.join_dataset_uri(f"#scheme/{pathify(column_name)}", use_true_dataset_root=True)
             return Resource(at_id=codelist_uri)
 
@@ -177,7 +177,17 @@ class CSVWMapping:
                 return Resource(at_id=codelist)
 
             # Codelist should exist. Convention dictates it should be a local codelist.
-            return get_conventional_local_codelist_uri(column_name)
+            return get_conventional_local_codelist_scheme_uri(column_name)
+
+        def get_convential_local_codelist_concept_uri_template(column_name: str) -> URI:
+            return self.join_dataset_uri(f"#concept/{pathify(column_name)}/{{{self._columns[column_name].name}}}",
+                                         use_true_dataset_root=True)
+
+        def get_value_uri_template_for_col(column_def: object, column_name: str) -> URI:
+            if "value" in column_def:
+                return URI(column_def["value"])
+
+            return get_convential_local_codelist_concept_uri_template(column_name)
 
         # Look to see whether the measure type has its own column
         for map_name, map_obj in self._mapping.items():
@@ -225,7 +235,7 @@ class CSVWMapping:
                     self._keys.append(self._columns[name].name)
                     self._columns[name] = self._columns[name]._replace(
                         propertyUrl=self.join_dataset_uri(f"#dimension/{pathify(name)}"),
-                        valueUrl=URI(obj["value"])
+                        valueUrl=get_value_uri_template_for_col(obj, name)
                     )
                     self._components.append(DimensionComponent(
                         at_id=self.join_dataset_uri(f"#component/{pathify(name)}"),
@@ -252,7 +262,7 @@ class CSVWMapping:
                     self._keys.append(self._columns[name].name)
                     self._columns[name] = self._columns[name]._replace(
                         propertyUrl=self.join_dataset_uri(f"#dimension/{pathify(name)}"),
-                        valueUrl=self.join_dataset_uri(f"#concept/{pathify(name)}/{{{self._columns[name].name}}}")
+                        valueUrl=get_value_uri_template_for_col(obj, name)
                     )
                     self._components.append(DimensionComponent(
                         at_id=self.join_dataset_uri(f"#component/{pathify(name)}"),
@@ -344,7 +354,7 @@ class CSVWMapping:
                 self._keys.append(self._columns[name].name)
                 self._columns[name] = self._columns[name]._replace(
                     propertyUrl=self.join_dataset_uri(f"#dimension/{pathify(name)}"),
-                    valueUrl=self.join_dataset_uri(f"#concept/{pathify(name)}/{{{self._columns[name].name}}}")
+                    valueUrl=get_convential_local_codelist_concept_uri_template(name)
                 )
                 self._components.append(DimensionComponent(
                     at_id=self.join_dataset_uri(f"#component/{pathify(name)}"),
@@ -354,7 +364,7 @@ class CSVWMapping:
                         rdfs_range=Resource(
                             at_id=self.join_dataset_uri(f"#class/{CSVWMapping.classify(name)}")
                         ),
-                        qb_codeList=get_conventional_local_codelist_uri(name),
+                        qb_codeList=get_conventional_local_codelist_scheme_uri(name),
                         rdfs_label=name,
                         rdfs_comment=description
                     )


### PR DESCRIPTION
Unfortunately, due to the convoluted nature of code in the `CSVWMapping` class, interesting values in the info.json get ignored in unexpected circumstances. 

I'm fixing one of them so we listen to the `value` specified for a given column, instead of overriding it and pretending it's available locally.