### PR TITLE
Adding support for metadata files with multiple tables listed

### DIFF
--- a/features/codelist-manager.feature
+++ b/features/codelist-manager.feature
@@ -301,7 +301,7 @@ Scenario: Creating New Global Level Metadata File from CSV with atypical column 
     }
     """
 
-  Scenario: Handling multi-table schemas.
+Scenario: Handling multi-table schemas.
     Given We have a CSV file named "my-favourite-code-list.csv" with headers
       """
       Some Column Name,Some Other Column Name
@@ -363,4 +363,32 @@ Scenario: Creating New Global Level Metadata File from CSV with atypical column 
             }
           ]
         }
+      """
+
+Scenario: Correct the "@id" when it's "#table" and we have skos:inScheme defined.
+    Given We have a metadata file of the form
+      """
+      {
+        "@context": "http://www.w3.org/ns/csvw",
+        "@id": "#table",
+        "url": "some-file.csv",
+        "tableSchema": {
+          "columns": [
+            {
+                "propertyUrl": "skos:inScheme",
+                "valueUrl": "http://gss-data.org.uk/def/concept-scheme/this-scheme-id"
+            }
+          ]
+        },
+        "prov:hadDerivation": {
+          "@type": "skos:ConceptScheme"
+        }
+      }
+      """
+    When We run an automatic upgrade on the metadata file
+    Then The following properties are set
+      """
+      {
+        "@id": "http://gss-data.org.uk/def/concept-scheme/this-scheme-id"
+      }
       """

--- a/features/codelist-manager.feature
+++ b/features/codelist-manager.feature
@@ -300,3 +300,67 @@ Scenario: Creating New Global Level Metadata File from CSV with atypical column 
       }
     }
     """
+
+  Scenario: Handling multi-table schemas.
+    Given We have a CSV file named "my-favourite-code-list.csv" with headers
+      """
+      Some Column Name,Some Other Column Name
+      """
+    And We have a metadata file of the form
+      """
+        {
+          "@context": "http://www.w3.org/ns/csvw",
+          "tables": [
+            {
+              "@id": "table-one",
+              "url": "table-one.csv",
+              "tableSchema": {},
+              "rdfs:label": "Table One"
+            },
+            {
+              "@id": "table-two",
+              "url": "table-two.csv",
+              "tableSchema": {},
+              "prov:hadDerivation": {
+                "@type": "skos:ConceptScheme"
+              },
+              "rdfs:label": "Table Two"
+            }
+          ]
+        }
+      """
+    When We run an automatic upgrade on the metadata file
+    Then The following properties are set
+      """
+        {
+          "@context": "http://www.w3.org/ns/csvw",
+          "tables": [
+            {
+              "@id": "table-one",
+              "url": "table-one.csv",
+              "tableSchema": {},
+              "rdfs:label": "Table One"
+            },
+            {
+              "@id": "table-two",
+              "url": "table-two.csv",
+              "tableSchema": {},
+              "prov:hadDerivation": {
+                "@type": ["skos:ConceptScheme", "http://publishmydata.com/pmdcat#ConceptScheme"]
+              },
+              "rdfs:label": "Table Two",
+              "rdfs:seeAlso": [
+                  {
+                      "@id": "table-two/dataset"
+                  },
+                  {
+                      "@id": "http://gss-data.org.uk/catalog/vocabularies"
+                  },
+                  {
+                      "@id": "table-two/catalog-record"
+                  }
+              ]
+            }
+          ]
+        }
+      """

--- a/gssutils/codelistmanager/applyupdates.py
+++ b/gssutils/codelistmanager/applyupdates.py
@@ -49,9 +49,9 @@ def _refactor_table_mapping_with_updates(table_mapping: Dict, allow_human_input:
 
     standardise_labels(table_mapping)
 
+    correct_id_if_table(table_mapping)
+
     catalog_label: str = table_mapping.get("rdfs:label")
 
     ensure_dcat_metadata_populated(pmdcat_base_uri, allow_human_input, concept_scheme_uri,
                                    table_mapping, dt_now, catalog_label)
-
-    correct_id_if_table(table_mapping)

--- a/gssutils/codelistmanager/applyupdates.py
+++ b/gssutils/codelistmanager/applyupdates.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, List
 from datetime import datetime
 
 from .updates.dcat import ensure_dcat_metadata_populated
@@ -7,20 +7,48 @@ from .config import pmdcat_base_uri
 
 
 def refactor_structure_with_updates(csvw_mapping: Dict, allow_human_input: bool):
+    if "tables" in csvw_mapping:
+        tables: List[Dict] = csvw_mapping["tables"]
+        for table in tables:
+            if _table_mapping_has_type(table, "skos:ConceptScheme"):
+                _refactor_table_mapping_with_updates(table, allow_human_input)
+            else:
+                id = table["@id"]
+                print(f"Ignoring table with ID {id} as it is not a skos:ConceptScheme")
+
+    elif _table_mapping_has_type(csvw_mapping, "skos:ConceptScheme"):
+        _refactor_table_mapping_with_updates(csvw_mapping, allow_human_input)
+    else:
+        id = csvw_mapping["@id"]
+        print(f"Ignoring table with ID {id} as it is not a skos:ConceptScheme")
+
+
+def _table_mapping_has_type(table_mapping: Dict, expected_type: str) -> bool:
+    if "prov:hadDerivation" in table_mapping:
+        derivation = table_mapping["prov:hadDerivation"]
+        if "@type" in derivation:
+            t = derivation["@type"]
+            return (isinstance(t, list) and expected_type in t) or (
+                    isinstance(t, str) and t == expected_type)
+
+    return False
+
+
+def _refactor_table_mapping_with_updates(table_mapping: Dict, allow_human_input: bool):
     """
     Applies schematic updates to the structure of `.csv-metadata.json` files.
     """
 
     # Populate our variables.
     dt_now = datetime.now().isoformat()
-    concept_scheme_uri: str = csvw_mapping["@id"]
-    csv_url: str = csvw_mapping["url"]
+    concept_scheme_uri: str = table_mapping["@id"]
+    csv_url: str = table_mapping["url"]
 
     print(f"Processing code list {csv_url}")
 
-    standardise_labels(csvw_mapping)
+    standardise_labels(table_mapping)
 
-    catalog_label: str = csvw_mapping.get("rdfs:label")
+    catalog_label: str = table_mapping.get("rdfs:label")
 
     ensure_dcat_metadata_populated(pmdcat_base_uri, allow_human_input, concept_scheme_uri,
-                                   csvw_mapping, dt_now, catalog_label)
+                                   table_mapping, dt_now, catalog_label)

--- a/gssutils/codelistmanager/applyupdates.py
+++ b/gssutils/codelistmanager/applyupdates.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from .updates.dcat import ensure_dcat_metadata_populated
 from .updates.standardiselabels import standardise_labels
+from .updates.correctidiftable import correct_id_if_table
 from .config import pmdcat_base_uri
 
 
@@ -52,3 +53,5 @@ def _refactor_table_mapping_with_updates(table_mapping: Dict, allow_human_input:
 
     ensure_dcat_metadata_populated(pmdcat_base_uri, allow_human_input, concept_scheme_uri,
                                    table_mapping, dt_now, catalog_label)
+
+    correct_id_if_table(table_mapping)

--- a/gssutils/codelistmanager/createnew.py
+++ b/gssutils/codelistmanager/createnew.py
@@ -1,6 +1,6 @@
 import re
 import csv
-from os import path
+from pathlib import Path
 from typing import List, Dict, Optional, Callable
 import json
 from enum import Enum
@@ -17,14 +17,14 @@ class CodeListLevel(Enum):
     Dataset = 2
 
 
-def create_metadata_shell_for_csv(csv_file_path: str) -> str:
+def create_metadata_shell_for_csv(csv_file_path: Path) -> Path:
     """
     Returns the path for the metadata file which has been created.
     """
-    metadata_file = f"{csv_file_path}-metadata.json"
-    if path.exists(metadata_file):
+    metadata_file = Path(f"{csv_file_path}-metadata.json")
+    if metadata_file.exists():
         raise Exception(f"Metadata file {metadata_file} already exists.")
-    if not path.exists(csv_file_path):
+    if not csv_file_path.exists():
         raise Exception(f"CSV file {csv_file_path} does not exist.")
 
     maybe_info_json_config = find_maybe_info_json_nearest_file(csv_file_path)
@@ -40,12 +40,12 @@ def create_metadata_shell_for_csv(csv_file_path: str) -> str:
     with open(metadata_file, 'w+') as file:
         file.write(json.dumps(metadata, indent=4))
 
-    return str(metadata_file)
+    return metadata_file
 
 
 def generate_csvw_metadata(
         column_names: List[str],
-        csv_file_path: str,
+        csv_file_path: Path,
         code_list_level: CodeListLevel,
         maybe_info_json_config: Optional[Dict],
         override_get_family_name_pathify: Optional[Callable[[], str]] = None
@@ -63,7 +63,7 @@ def generate_csvw_metadata(
     metadata = {
         "@context": "http://www.w3.org/ns/csvw",
         "@id": concept_scheme_uri,
-        "url": csv_file_path,
+        "url": str(csv_file_path),
         "rdfs:label": label,
         "dc:title": label,
         "tableSchema": {
@@ -120,8 +120,8 @@ def _map_concept_scheme_uri_to_concept_base(concept_scheme_uri: str) -> str:
         return concept_scheme_uri
 
 
-def _map_file_path_to_label(file_path: str) -> str:
-    file_name_without_ext = re.sub(".*?([^/]+)\\..*$", "\\1", file_path)
+def _map_file_path_to_label(file_path: Path) -> str:
+    file_name_without_ext = re.sub(".*?([^/]+)\\..*$", "\\1", str(file_path))
     return file_name_without_ext.replace("-", " ").title()
 
 

--- a/gssutils/codelistmanager/infojson.py
+++ b/gssutils/codelistmanager/infojson.py
@@ -1,30 +1,26 @@
 from typing import Optional, Dict
-from os import path
+from pathlib import Path
 import json
 
 
-def find_maybe_info_json_nearest_file(file_path: str) -> Optional[Dict]:
-    if not path.isabs(file_path):
-        file_path = path.abspath(file_path)
+def find_maybe_info_json_nearest_file(file_path: Path) -> Optional[Dict]:
+    if not file_path.is_absolute():
+        file_path = file_path.absolute()
 
-    [file_directory, _] = path.split(file_path)
-    return find_maybe_info_json(file_directory)
+    return find_maybe_info_json(file_path.parent)
 
 
-def find_maybe_info_json(absolute_directory_path: str) -> Optional[Dict]:
+def find_maybe_info_json(absolute_directory_path: Path) -> Optional[Dict]:
     """
     Recursively search parent folders to find the closest info.json file.
     """
 
-    possible_info_json_path = path.join(absolute_directory_path, "info.json")
-    if path.exists(possible_info_json_path):
+    possible_info_json_path = absolute_directory_path.joinpath("info.json")
+    if possible_info_json_path.exists():
         with open(possible_info_json_path, 'r') as file:
             return json.loads(file.read())
 
-    path_parts = path.split(absolute_directory_path)
-    if len(path_parts) == 1:
+    if len(absolute_directory_path.parts) == 1:
         return None
 
-    [parent_dir, _] = path_parts
-
-    return find_maybe_info_json(parent_dir)
+    return find_maybe_info_json(absolute_directory_path.parent)

--- a/gssutils/codelistmanager/main.py
+++ b/gssutils/codelistmanager/main.py
@@ -5,7 +5,7 @@ Call with `--help` arg for further instructions.
 """
 
 import json
-import glob
+from pathlib import Path
 from typing import List
 import argparse
 
@@ -26,15 +26,15 @@ def codelist_manager():
                         action='store_true')
     args = parser.parse_args()
 
-    metadata_files: List[str]
+    metadata_files: List[Path]
     if args.schema is not None:
-        metadata_files = [args.schema]
+        metadata_files = [Path(args.schema)]
     elif args.upgrade_all:
-        metadata_files = glob.glob("**/*.csv-metadata.json", recursive=True)
+        metadata_files = Path(".").rglob("**/*.csv-metadata.json")
     elif args.csv is not None:
         if args.auto:
             raise Exception("Cannot create a new metadata file from an existing CSV without human input.")
-        metadata_files = [create_metadata_shell_for_csv(args.csv)]
+        metadata_files = [create_metadata_shell_for_csv(Path(args.csv))]
     else:
         parser.print_help()
         exit()

--- a/gssutils/codelistmanager/updates/correctidiftable.py
+++ b/gssutils/codelistmanager/updates/correctidiftable.py
@@ -1,0 +1,37 @@
+"""
+An upgrade to correct the "@id" property where it is set to "#table".
+
+This only works if we have a column definition which specifies where the skos:ConceptScheme is.
+"""
+from typing import Dict, List, Optional
+
+from .nodes.utils import find
+
+
+def _get_concept_scheme_uri_from_cols(cols: List[Dict]) -> Optional[str]:
+    for col in cols:
+        # "propertyUrl": "skos:inScheme",
+        # "valueUrl": "http://gss-data.org.uk/def/concept-scheme/labour-market-age-categories"
+        property_url = col.get("propertyUrl")
+        value_url = col.get("valueUrl")
+        if property_url is not None and property_url == "skos:inScheme" and value_url is not None:
+            return value_url
+
+    return None
+
+
+def correct_id_if_table(
+        table_mapping: Dict
+):
+    table_id = table_mapping["@id"]
+    if table_id != "#table":
+        return
+
+    # Else, the table has it #table. This is wrong.
+    if "tableSchema" in table_mapping:
+        table_schema = table_mapping["tableSchema"]
+        if "columns" in table_schema:
+            columns = table_schema["columns"]
+            concept_scheme_uri = _get_concept_scheme_uri_from_cols(columns)
+            if concept_scheme_uri is not None:
+                table_mapping["@id"] = concept_scheme_uri

--- a/gssutils/codelistmanager/updates/dcat.py
+++ b/gssutils/codelistmanager/updates/dcat.py
@@ -10,14 +10,14 @@ def ensure_dcat_metadata_populated(
         pmdcat_base_uri: str,
         allow_human_input: bool,
         concept_scheme_uri: str,
-        csvw_mapping: Dict,
+        table_mapping: Dict,
         dt_now: str,
         catalog_label: str
 ):
     """
     Ensures that the relevant PMDCAT and DCAT metadata is linked to the ConceptScheme.
     """
-    prov_derivation_object = csvw_mapping["prov:hadDerivation"]
+    prov_derivation_object = table_mapping["prov:hadDerivation"]
 
     catalog_record_uri = concept_scheme_uri + "/catalog-record"
     dataset_uri = concept_scheme_uri + "/dataset"
@@ -26,7 +26,7 @@ def ensure_dcat_metadata_populated(
 
     # Ensure rdfs:seeAlso section is populated with dcat:CatalogRecord,
     # dcat:Dataset and a link between the top-level codelist catalog and the CatalogRecord for this codelist.
-    rdfs_see_also: List[Dict] = csvw_mapping.get("rdfs:seeAlso", [])
+    rdfs_see_also: List[Dict] = table_mapping.get("rdfs:seeAlso", [])
     dataset_node = find(rdfs_see_also, is_dataset_node)
     if not dataset_node:
         dataset_node = {}
@@ -53,7 +53,7 @@ def ensure_dcat_metadata_populated(
     configure_catalog_record(pmdcat_base_uri, catalog_record, catalog_record_uri, concept_scheme_uri, dataset_uri,
                              dt_now, catalog_label)
 
-    csvw_mapping["rdfs:seeAlso"] = rdfs_see_also
+    table_mapping["rdfs:seeAlso"] = rdfs_see_also
 
 
 def _ensure_type_updated(pmdcat_base_uri: str, prov_derivation_object: Dict):

--- a/gssutils/codelistmanager/updates/dcat.py
+++ b/gssutils/codelistmanager/updates/dcat.py
@@ -37,7 +37,8 @@ def ensure_dcat_metadata_populated(
         allow_human_input,
         concept_scheme_uri,
         dataset_uri,
-        catalog_label
+        catalog_label,
+        dt_now
     )
 
     catalog_record_catalog_link = find(rdfs_see_also, is_catalog_record_link_node)

--- a/gssutils/codelistmanager/updates/nodes/dataset.py
+++ b/gssutils/codelistmanager/updates/nodes/dataset.py
@@ -14,7 +14,8 @@ def configure_dataset_node(
         allow_human_input: bool,
         concept_scheme_uri: str,
         dataset_uri: str,
-        catalog_label: str
+        catalog_label: str,
+        dt_now: str
 ):
     override(dataset_node, {
         "@id": dataset_uri,
@@ -27,13 +28,18 @@ def configure_dataset_node(
         },
         f"{pmdcat_base_uri}graph": {
             "@id": concept_scheme_uri
-        }
+        },
+        "dc:modified": {"@type": "dateTime",
+                        "@value": dt_now}
     })
 
     supplement(dataset_node, {
         "rdfs:label": catalog_label,
         "dc:title": catalog_label,
-        "rdfs:comment": f"Dataset representing the '{catalog_label}' code list."
+        "rdfs:comment": f"Dataset representing the '{catalog_label}' code list.",
+        "dc:issued": {"@type": "dateTime",
+                      "@value": dt_now}
+
     })
 
     if allow_human_input:
@@ -63,18 +69,6 @@ def configure_dataset_node(
                 "name": "dcat:landingPage",
                 "input_request": "Landing Page URL (user landing for Download)",
                 "to_value": lambda landing_uri: {"@id": landing_uri}
-            },
-            {
-                "name": "dc:issued",
-                "input_request": "Date issued/created/published (YYYY-mm-dd)",
-                "to_value": lambda input_value: {"@type": "dateTime",
-                                                 "@value": datetime.strptime(input_value, "%Y-%m-%d").isoformat()}
-            },
-            {
-                "name": "dc:modified",
-                "input_request": "Date modified (YYYY-mm-dd)",
-                "to_value": lambda input_value: {"@type": "dateTime",
-                                                 "@value": datetime.strptime(input_value, "%Y-%m-%d").isoformat()}
             },
             {
                 "name": f"{pmdcat_base_uri}markdownDescription",


### PR DESCRIPTION
Upgrading the codelist-manager so that it can add metadata to CSV-W json files which reference multiple tables. It inspects every table and only upgrades ones which have type `skos:ConceptScheme`.

I've also refactored the code to use python's `pathlib` instead of `os.path`.