### PR TITLE
unencapsulating get_chunks methods

### DIFF
--- a/features/steps/download.py
+++ b/features/steps/download.py
@@ -82,7 +82,7 @@ def step_impl(context):
 def step_impl(context):
     with vcr.use_cassette("features/fixtures/cassettes/odata_api.yml",
                           record_mode=context.config.userdata.get('record_mode', 'DEFAULT_RECORD_MODE')):
-        api_chunks = list(set(context.distro._get_odata_api_chunks()))
+        api_chunks = list(set(context.distro.get_odata_api_chunks()))
         expected_chunks = [int(x.strip()) for x in context.text.split(",")]
         assert set(api_chunks) == set(expected_chunks), \
             f'Expecting "{expected_chunks}". \nGot "{api_chunks}".'
@@ -92,7 +92,7 @@ def step_impl(context):
 def step_impl(context):
     with vcr.use_cassette("features/fixtures/cassettes/pmd4.yml",
                           record_mode=context.config.userdata.get('record_mode', 'DEFAULT_RECORD_MODE')):
-        pmd_chunks = list(set(context.distro._get_pmd_chunks()))
+        pmd_chunks = list(set(context.distro.get_pmd_chunks()))
         expected_chunks = [x.strip() for x in context.text.split(",")]
         assert set(pmd_chunks) == set(expected_chunks), \
             f'Expecting "{expected_chunks}". \nGot "{pmd_chunks}".'

--- a/gssutils/transform/download.py
+++ b/gssutils/transform/download.py
@@ -206,7 +206,7 @@ class Downloadable(Resource):
 
         return df
 
-    def _get_pmd_chunks(self) -> list:
+    def get_pmd_chunks(self) -> list:
         """
         Given the downloadURL from the scraper, return a list of chunks from pmd4
         """
@@ -232,7 +232,7 @@ SELECT DISTINCT ?chunk WHERE {{
         return [x['chunk']['value'] for x in result['results']['bindings']]
 
     @backoff.on_exception(backoff.expo, requests.exceptions.RequestException)
-    def _get_odata_api_chunks(self) -> list:
+    def get_odata_api_chunks(self) -> list:
         """
         Given the downloadURL from the scraper, return a list of chunks from the odata api
         """


### PR DESCRIPTION
Just a small change to download.py both method and tests to remove the underscore prefix for get_odata_api_chunks and get_pmd_chunks, which now are accessible without passing the distro to it, as they are now distro functions which are called by `distribution(latest=True).get_odata_api_chunks`, etc.