### PR TITLE
Change secondary role of qb:DataSet from dcat:Dataset to pmdcat:DataCube

### DIFF
--- a/gssutils/csvw/dsd.py
+++ b/gssutils/csvw/dsd.py
@@ -64,5 +64,5 @@ class DSD(NamedTuple):
 
 class DataSet(NamedTuple):
     at_id: URI = '#dataset'
-    at_type: Union[URI, List[URI]] = ["qb:DataSet", "dcat:Dataset"]
+    at_type: Union[URI, List[URI]] = ["qb:DataSet", "pmdcat:DataCube"]
     qb_structure: DSD = DSD()

--- a/gssutils/csvw/namespaces.py
+++ b/gssutils/csvw/namespaces.py
@@ -24,6 +24,7 @@ prefix_map: Dict[str, URI] = {
     "og": "http://ogp.me/ns#",
     "org": "http://www.w3.org/ns/org#",
     "owl": "http://www.w3.org/2002/07/owl#",
+    "pmdcat": "http://publishmydata.com/pmdcat#",
     "prov": "http://www.w3.org/ns/prov#",
     "qb": "http://purl.org/linked-data/cube#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",


### PR DESCRIPTION
We had declared that all `qb:DataSet`s were also `dcat:Dataset`s. I believe this is a legacy of the way PMD3 was considering things and is not how we want to model things in future.

I've changed to using `pmdcat:DataCube` as the secondary role of a `qb:DataSet`, though I'd prefer not to encumber the data publisher with this requirement -- we should push this kind of annotation downstream towards PMD.