### PR TITLE
 Bug/empty ons distributions

### DIFF
--- a/features/scrape.feature
+++ b/features/scrape.feature
@@ -265,6 +265,13 @@ Feature: Scrape dataset info
   Scenario: ONS scrape from url
     Given I scrape the page "https://www.ons.gov.uk/peoplepopulationandcommunity/wellbeing/datasets/coronaviruspersonalandeconomicwellbeingimpacts"
 
+  Scenario: ONS scrape single distribution url
+    Given I scrape the page "https://www.ons.gov.uk/businessindustryandtrade/internationaltrade/datasets/regionalisedestimatesofukserviceexports"
+    And select the distribution given by
+      | key       | value                                                                 |
+      | latest    | application/vnd.openxmlformats-officedocument.spreadsheetml.sheet     |
+    Then the data can be downloaded from "https://www.ons.gov.uk/file?uri=/economy/nationalaccounts/balanceofpayments/datasets/tradeingoodsmretsallbopeu2013timeseriesspreadsheet/current/previous/v11/mret.csdb"
+
   Scenario: deal with ONS publication datetime as Europe/London date.
     Given I scrape the page "https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/datasets/deathsinvolvingcovid19inthecaresectorenglandandwales"
     Then the publication date should match "2020-07-03"

--- a/features/scrape.feature
+++ b/features/scrape.feature
@@ -265,7 +265,7 @@ Feature: Scrape dataset info
   Scenario: ONS scrape from url
     Given I scrape the page "https://www.ons.gov.uk/peoplepopulationandcommunity/wellbeing/datasets/coronaviruspersonalandeconomicwellbeingimpacts"
 
-  Scenario: ONS scrape single distribution url
+  Scenario: ONS scrape a distribution with zero versions
     Given I scrape the page "https://www.ons.gov.uk/businessindustryandtrade/internationaltrade/datasets/regionalisedestimatesofukserviceexports"
     And select the distribution given by
       | key       | value                                                                 |

--- a/features/scrape.feature
+++ b/features/scrape.feature
@@ -270,7 +270,7 @@ Feature: Scrape dataset info
     And select the distribution given by
       | key       | value                                                                 |
       | latest    | application/vnd.openxmlformats-officedocument.spreadsheetml.sheet     |
-    Then the data can be downloaded from "https://www.ons.gov.uk/file?uri=/economy/nationalaccounts/balanceofpayments/datasets/tradeingoodsmretsallbopeu2013timeseriesspreadsheet/current/previous/v11/mret.csdb"
+    Then the data can be downloaded from "https://www.ons.gov.uk/file?uri=/businessindustryandtrade/internationaltrade/datasets/regionalisedestimatesofukserviceexports/2011to2016/nuts1serviceexports20112016.xls"
 
   Scenario: deal with ONS publication datetime as Europe/London date.
     Given I scrape the page "https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/datasets/deathsinvolvingcovid19inthecaresectorenglandandwales"

--- a/gssutils/scrapers/ons.py
+++ b/gssutils/scrapers/ons.py
@@ -164,15 +164,25 @@ def handler_dataset_landing_page(scraper, landing_page, tree):
         # create a list, with each entry a dict of a versions url and update date
         versions_dict_list = []
 
-        # iterate all versions and populate the list
-        try:
-            for version_as_dict in this_dataset_page["versions"]:
-                versions_dict_list.append({
-                    "url": ONS_PREFIX+version_as_dict["uri"]+"/data",
-                    "update_date": version_as_dict["updateDate"]
-                })
-        except KeyError:
-            logging.debug("No older versions found for {}.".format(dataset_page_url))
+        # Where the dataset is versioned, use the versions as the distributions
+        all_versions = this_dataset_page["versions"]
+
+        # Where there's multiple versions, iterate all and populate a list
+        if len(all_versions) != 0:
+            try:
+                for version_as_dict in all_versions:
+                    versions_dict_list.append({
+                        "url": ONS_PREFIX+version_as_dict["uri"]+"/data",
+                        "update_date": version_as_dict["updateDate"]
+                    })
+            except KeyError:
+                logging.debug("No older versions found for {}.".format(dataset_page_url))
+        else:
+            # Otherwise creatd a single item list representing the current/only release of the data
+            versions_dict_list.append({
+                        "url": ONS_PREFIX+this_dataset_page["uri"]+"/data",
+                        "update_date": this_dataset_page["description"]["releaseDate"]
+                    })
 
         # NOTE - we've had an issue with the very latest dataset not being updated on the previous versions
         # page (the page we're getting the distributions from) so we're taking the details for it from


### PR DESCRIPTION
Where dataset versions field of the ONS /data endpoints, are only populated when 2 or more version of a dataset have been release, eg:

1.) 1 distribution has 0 versions
2.) 2 distributions has 2 versions
3.) 3 distributions has 3 versions

when we updated the handling to look for updatedDate (to fix release date bug) it doesn't account for scenario 1.

this pr adds a fallback, so where there are 0 version of a dataset, we use the principle page information instead.