### PR TITLE
catch for ons-scraper,  no initial release date

### DIFF
--- a/features/scrape.feature
+++ b/features/scrape.feature
@@ -275,6 +275,12 @@ Feature: Scrape dataset info
       | latest    | application/vnd.openxmlformats-officedocument.spreadsheetml.sheet     |
     Then the data can be downloaded from "https://www.ons.gov.uk/file?uri=/businessindustryandtrade/internationaltrade/datasets/regionalisedestimatesofukserviceexports/2011to2016/nuts1serviceexports20112016.xls"
 
+  Scenario: ONS scrape distributions but ignore initial versions with no stated release date
+    Given I scrape the page "https://www.ons.gov.uk/businessindustryandtrade/internationaltrade/datasets/uktradeingoodsbyclassificationofproductbyactivity"
+    And select the oldest "text/csv" distribution
+    Then the data can be downloaded from "https://www.ons.gov.uk/file?uri=/businessindustryandtrade/internationaltrade/datasets/uktradeingoodsbyclassificationofproductbyactivity/current/previous/v3/mq10.csv"
+
+
   Scenario: deal with ONS publication datetime as Europe/London date.
     Given I scrape the page "https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/datasets/deathsinvolvingcovid19inthecaresectorenglandandwales"
     Then the publication date should match "2020-07-03"

--- a/features/steps/scrape.py
+++ b/features/steps/scrape.py
@@ -152,6 +152,13 @@ def step_impl(context, tabname):
         context.pandas = context.distribution.as_pandas(sheet_name=tabname)
 
 
+@step('select the oldest "{media_type}" distribution')
+def step_impl(context, media_type):
+    oldest = min([x.issued for x in context.scraper.distributions])
+    context.distribution = context.scraper.distribution(issued=oldest, mediaType=media_type)
+    assert_is_not_none(context.distribution)
+
+
 @then("the dataframe should have {rows:d} rows")
 def step_impl(context, rows):
     dfrows, dfcols = context.pandas.shape

--- a/gssutils/scrapers/ons.py
+++ b/gssutils/scrapers/ons.py
@@ -176,13 +176,10 @@ def handler_dataset_landing_page(scraper, landing_page, tree):
         # WAS SUPERCEDED (so the release fate of the NEXT version of the data).
         # ......this takes a bit of unpicking.
 
-        try:
-            initial_release = this_dataset_page["description"]["releaseDate"]
-        except KeyError:
-            # No initial release date for the dataset has been provided
-            # We're just going to ignore v1, we don't have a use for it
-            # and with no provided release date ... not a lot to be done
-            initial_release = None
+        # If no initial release date for the dataset has been provided
+        # We're just going to ignore v1, we don't have a use for it
+        # and with no provided release date ... not a lot to be done
+        initial_release = this_dataset_page["description"].get("releaseDate", None)
 
         next_release = None
         # Where there's multiple versions, iterate all and populate a list


### PR DESCRIPTION
set the ons scraper to ignore initial (v1) distributions that don't have a release date (rather than falling over as it'll currently do).

also tidied up some old exceptions, one was related to legacy approach to release dates we don't use anymore, the other was raising an exception and killing the scrape where a warning would have done. 