### PR TITLE
Alter default Concept URIs for family and ref_common level codelists …

### DIFF
--- a/features/codelist-manager.feature
+++ b/features/codelist-manager.feature
@@ -152,7 +152,7 @@ Feature: Create and Manage CodeList Metadata files
                         },
                         "required": false,
                         "propertyUrl": "skos:broader",
-                        "valueUrl": "http://gss-data.org.uk/def/concept-scheme/my-favourite-code-list/{parent_notation}"
+                        "valueUrl": "http://gss-data.org.uk/def/concept/my-favourite-code-list/{parent_notation}"
                     },
                     {
                         "titles": "Sort Priority",
@@ -180,7 +180,7 @@ Feature: Create and Manage CodeList Metadata files
                     }
                 ],
                 "primaryKey": "notation",
-                "aboutUrl": "http://gss-data.org.uk/def/concept-scheme/my-favourite-code-list/{notation}"
+                "aboutUrl": "http://gss-data.org.uk/def/concept/my-favourite-code-list/{notation}"
             },
             "prov:hadDerivation": {
                 "@id": "http://gss-data.org.uk/def/concept-scheme/my-favourite-code-list",
@@ -207,14 +207,14 @@ Feature: Create and Manage CodeList Metadata files
                 "columns": [
                     {
                         "propertyUrl": "skos:broader",
-                        "valueUrl": "http://gss-data.org.uk/def/my-favourite-family/concept-scheme/my-favourite-code-list/{parent_notation}"
+                        "valueUrl": "http://gss-data.org.uk/def/my-favourite-family/concept/my-favourite-code-list/{parent_notation}"
                     },
                     {
                         "propertyUrl": "skos:inScheme",
                         "valueUrl": "http://gss-data.org.uk/def/my-favourite-family/concept-scheme/my-favourite-code-list"
                     }
                 ],
-                "aboutUrl": "http://gss-data.org.uk/def/my-favourite-family/concept-scheme/my-favourite-code-list/{notation}"
+                "aboutUrl": "http://gss-data.org.uk/def/my-favourite-family/concept/my-favourite-code-list/{notation}"
             },
             "prov:hadDerivation": {
                 "@id": "http://gss-data.org.uk/def/my-favourite-family/concept-scheme/my-favourite-code-list"

--- a/gssutils/codelistmanager/createnew.py
+++ b/gssutils/codelistmanager/createnew.py
@@ -114,10 +114,13 @@ def _map_concept_scheme_uri_to_concept_base(concept_scheme_uri: str) -> str:
     Family and Global codelists don't follow this rule and since URIs aren't auto-generated it isn't such a problem.
     """
     hash_url_match_regex = r"(.*)#scheme(/.*)?"
+    family_global_concept_scheme_uri_regex = r"(.*/)concept-scheme(/.*)?"
     if re.match(hash_url_match_regex, concept_scheme_uri):
         return re.sub(hash_url_match_regex, "\\1#concept\\2", concept_scheme_uri)
+    elif re.match(family_global_concept_scheme_uri_regex, concept_scheme_uri):
+        return re.sub(family_global_concept_scheme_uri_regex, "\\1concept\\2", concept_scheme_uri)
     else:
-        return concept_scheme_uri
+        raise Exception(f"Unmatched concept URI format for '{concept_scheme_uri}'.")
 
 
 def _map_file_path_to_label(file_path: Path) -> str:


### PR DESCRIPTION
…to be more consistent with what's used at the dataset level.

https://onswebsite.slack.com/archives/CP78UD9LZ/p1614347223008700