### PR TITLE
Accretive Upload - Stop generating Trig and DSD

### DIFF
--- a/features/csvw.feature
+++ b/features/csvw.feature
@@ -388,3 +388,13 @@ Scenario: Ensure column definition `value` field is respected when `parent` is n
           <#dimension/undefined-flow> <#concept/undefined-flow/exports>
           .
     """
+
+ Scenario: Do not output Data Structure Definition or Trig when performing an accretive upload
+    Given a CSV file 'product-observations.csv'
+    And a JSON map file 'mapping-info-accretive-test.json'
+    And a dataset URI 'http://gss-data.org.uk/data/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity'
+    When I create a CSVW file from the mapping and CSV
+    Then the metadata is valid JSON-LD
+    And gsscogs/csv2rdf generates RDF
+    And the RDF should pass the Data Cube integrity constraints
+    And the ask query 'dsd-components-exist.sparql' should return False

--- a/features/fixtures/dsd-components-exist.sparql
+++ b/features/fixtures/dsd-components-exist.sparql
@@ -1,0 +1,31 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX void: <http://rdfs.org/ns/void#>
+PREFIX pmdkos: <http://publishmydata.com/def/pmdkos/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX pmdui: <http://publishmydata.com/def/pmdui/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX markdown: <https://www.w3.org/ns/iana/media-types/text/markdown#>
+PREFIX qb: <http://purl.org/linked-data/cube#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX measure: <http://gss-data.org.uk/def/measure/>
+PREFIX sdmx: <http://purl.org/linked-data/sdmx/2009/attribute#>
+PREFIX measureUnit: <http://gss-data.org.uk/def/concept/measurement-units/>
+PREFIX pmdcat: <http://publishmydata.com/pmdcat#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+
+ASK
+WHERE {
+    {
+        ?dataSet a qb:DataSet.
+    } UNION {
+        ?dimension a qb:Dimension.
+    } UNION {
+        ?attribute a qb:Attribute.
+    } UNION {
+        ?measure a qb:Measure.
+    }
+}

--- a/features/fixtures/mapping-info-accretive-test.json
+++ b/features/fixtures/mapping-info-accretive-test.json
@@ -1,0 +1,52 @@
+{
+  "title": "UK trade in goods by industry, country and commodity, exports",
+  "publisher": "Office for National Statistics",
+  "description": "Experimental dataset providing a breakdown of UK trade in goods by industry, country and commodity on a balance of payments basis. Data are subject to disclosure control, which means some data have been suppressed to protect confidentiality of individual traders.",
+  "landingPage": [
+    "https://www.ons.gov.uk/economy/nationalaccounts/balanceofpayments/datasets/uktradeingoodsbyindustrycountryandcommodityimports",
+    "https://www.ons.gov.uk/economy/nationalaccounts/balanceofpayments/datasets/uktradeingoodsbyindustrycountryandcommodityexports"
+  ],
+  "published": "2019-04-14",
+  "families": [
+    "Trade"
+  ],
+  "extract": {
+    "source": "XLS",
+    "stage": "Done"
+  },
+  "transform": {
+    "airtable": [
+      "rec6SvP3d4MJ3pXYR",
+      "recduvpZS53BpXU3W"
+    ],
+    "main_issue": 3,
+    "columns": {
+      "Year": {
+        "dimension": "http://purl.org/linked-data/sdmx/2009/dimension#refPeriod",
+        "value": "http://reference.data.gov.uk/id/year/{year}"
+      },
+      "Country": {
+        "dimension": "http://gss-data.org.uk/def/dimension/ons-partner-geography",
+        "value": "http://gss-data.org.uk/def/concept-scheme/sdmx-bop/cl_area/{country}"
+      },
+      "Direction": {
+        "dimension": "http://gss-data.org.uk/def/dimension/flow-directions",
+        "value": "http://gss-data.org.uk/def/concept/flow-directions/{direction}"
+      },
+      "Marker": {
+        "attribute": "http://purl.org/linked-data/sdmx/2009/attribute#obsStatus",
+        "value": "http://gss-data.org.uk/def/concept/marker/{marker}"
+      },
+      "Value": {
+        "unit": "http://gss-data.org.uk/def/concept/measurement-units/gbp",
+        "measure": "http://gss-data.org.uk/def/measure/gbp-total",
+        "datatype": "number"
+      }
+    }
+  },
+  "load": {
+    "accretiveUpload": true
+  },
+  "sizingNotes": "",
+  "notes": ""
+}

--- a/features/steps/csvw.py
+++ b/features/steps/csvw.py
@@ -266,6 +266,9 @@ def step_impl(context):
     context.csvw.set_input(context.csv_filename, context.csv_io)
     context.json_io.seek(0)
     context.csvw.set_mapping(json.load(context.json_io))
+    context.json_io.seek(0)
+    context.csvw.set_accretive_upload(json.load(context.json_io))
+
     if hasattr(context, 'registry'):
         context.csvw.set_registry(URI(context.registry))
     if hasattr(context, 'dataset_uri'):

--- a/features/steps/rdf.py
+++ b/features/steps/rdf.py
@@ -7,6 +7,7 @@ from rdflib import Graph
 from dateutil.parser import parse
 from datetime import datetime, timezone
 from gssutils.metadata import THEME
+import distutils.util
 
 
 @step("set the base URI to <{uri}>")
@@ -64,6 +65,18 @@ def step_impl(context):
         Graph().parse(format='turtle', data=context.turtle),
         Graph().parse(format='turtle', data=context.text)
     )
+
+
+@step("the ask query '{query_file}' should return {expected_query_result}")
+def step_impl(context, query_file: str, expected_query_result: str):
+    query_file = Path('features') / 'fixtures' / query_file
+    with open(query_file) as f:
+        query = f.read()
+    g = Graph().parse(format='turtle', data=context.turtle)
+    results = list(g.query(query))
+    ask_result = results[0]
+    expected_ask_result = bool(distutils.util.strtobool(expected_query_result))
+    assert(ask_result == expected_ask_result)
 
 
 @step("set the family to '{family}'")


### PR DESCRIPTION
When we're doing an accretive upload, we need to ensure that the Data Structure Definition and the trig file containing catalogue metadata aren't generated so that we don't duplicate information which is already stored on PMD.

This isn't a problem with our standard uploads since they're done in a drop-and-replace fashion, but this has become an issue now that we're keeping the existing data and adding new qb:Observations to the dataset. 

Part of https://github.com/GSS-Cogs/pmd-jenkins-library/issues/53