### PR TITLE
Allow specifying only parent dimension

### DIFF
--- a/features/csvw.feature
+++ b/features/csvw.feature
@@ -398,3 +398,23 @@ Scenario: Ensure column definition `value` field is respected when `parent` is n
     And gsscogs/csv2rdf generates RDF
     And the RDF should pass the Data Cube integrity constraints
     And the ask query 'dsd-components-exist.sparql' should return False
+
+
+Scenario: A user wishes to specify a parent dimension for a locally defined dataset dimension
+    Given a CSV file 'life-expectancy.csv'
+    And a JSON map file 'life-expectancy.json'
+    And a dataset URI 'http://gss-data.org.uk/data/gss_data/health/life-expectancy-in-newport'
+    When I create a CSVW file from the mapping and CSV
+    Then the metadata is valid JSON-LD
+    And gsscogs/csv2rdf generates RDF
+    And the RDF should pass the Data Cube integrity constraints
+    And the RDF should contain
+    """
+      @base <http://gss-data.org.uk/data/gss_data/health/life-expectancy-in-newport> .
+      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+      @prefix qb: <http://purl.org/linked-data/cube#> .
+
+      <#dimension/region> a qb:DimensionProperty ;
+          qb:codeList <http://gss-data.org.uk/data/gss_data/health/life-expectancy-in-newport#scheme/region> ;
+          rdfs:subPropertyOf <http://purl.org/linked-data/sdmx/2009/dimension#refPeriod> .
+    """

--- a/features/fixtures/life-expectancy.csv
+++ b/features/fixtures/life-expectancy.csv
@@ -1,0 +1,2 @@
+Life Expectancy,Region
+76.7,Newport

--- a/features/fixtures/life-expectancy.json
+++ b/features/fixtures/life-expectancy.json
@@ -1,0 +1,36 @@
+{
+    "id": "life-expectancy-in-newport",
+    "title": "Life Expectancy in Newport",
+    "publisher": "Office for National Statistics",
+    "description": "Experimental dataset providing a breakdown of Life Expectancy.",
+    "landingPage": [
+        "https://www.ons.gov.uk/life-expectancy"
+    ],
+    "published": "2019-04-14",
+    "families": [
+        "Health"
+    ],
+    "extract": {
+        "source": "XLS",
+        "stage": "Done"
+    },
+    "transform": {
+        "airtable": [
+            "rec6SvP3d4MJ3pXYR",
+            "recduvpZS53BpXU3W"
+        ],
+        "main_issue": 3,
+        "columns": {
+            "Region": {
+                "parent": "http://purl.org/linked-data/sdmx/2009/dimension#refPeriod"
+            },
+            "Life Expectancy": {
+                "unit": "http://gss-data.org.uk/def/concept/years",
+                "measure": "http://gss-data.org.uk/def/measure/life-expectancy",
+                "datatype": "number"
+            }
+        }
+    },
+    "sizingNotes": "",
+    "notes": ""
+}

--- a/gssutils/csvw/mapping.py
+++ b/gssutils/csvw/mapping.py
@@ -213,7 +213,11 @@ class CSVWMapping:
                         )
         # Now iterate over column headers in the given CSV file
         for name in self._column_names:
-            if self._mapping is not None and name in self._mapping and isinstance(self._mapping[name], dict):
+            if (
+                self._mapping is not None 
+                and name in self._mapping 
+                and isinstance(self._mapping[name], dict)
+            ):
                 obj = self._mapping[name]
                 if "dimension" in obj and "value" in obj:
                     self._keys.append(self._columns[name].name)
@@ -231,7 +235,7 @@ class CSVWMapping:
                             )
                         )
                     ))
-                elif "parent" in obj and "value" in obj:
+                elif "parent" in obj:
                     # a local dimension that has a super property
                     description: Optional[str] = obj.get("description", None)
                     label: str = obj.get("label", name)


### PR DESCRIPTION
See https://github.com/GSS-Cogs/gss-utils/issues/224.

For local dimensions with local codelists, we want `CSVWMapping()` to generate default URIs but also to have the ability for the user to specify a parent URI as part of the `info.json`.

For example,
```json
{
    "Region": {
        "parent": "http://purl.org/linked-data/sdmx/2009/dimension#refPeriod"
    }
}
```

Should produce `.ttl` of the form:
```ttl
      <#dimension/region> a qb:DimensionProperty ;
          qb:codeList <#scheme/region> ;
          rdfs:subPropertyOf <http://purl.org/linked-data/sdmx/2009/dimension#refPeriod> .
```