### PR TITLE
Alter how Graph URI is decided for datasets generated by gss-utils

### DIFF
--- a/features/csvw.feature
+++ b/features/csvw.feature
@@ -432,9 +432,9 @@ Scenario: A user wishes to specify a parent dimension for a locally defined data
     @prefix sd: <http://www.w3.org/ns/sparql-service-description#>.
     @prefix void: <http://rdfs.org/ns/void#>.
 
-    <http://gss-data.org.uk/data/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity#graph>
+    <http://gss-data.org.uk/graph/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity>
         a sd:NamedGraph;
-        sd:name <http://gss-data.org.uk/data/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity#graph>;
+        sd:name <http://gss-data.org.uk/graph/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity>;
         void:rootResource <http://gss-data.org.uk/data/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity#dataset>.
     """
 
@@ -442,7 +442,7 @@ Scenario: Manually Overriding CSV-W's graph URI works.
     Given a CSV file 'product-observations.csv'
     And a JSON map file 'mapping-info.json'
     And a dataset URI 'http://gss-data.org.uk/data/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity'
-    And a containing graph URI 'http://gss-data.org.uk/graph/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity'
+    And a containing graph URI 'http://gss-data.org.uk/graph2/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity'
     When I create a CSVW file from the mapping and CSV
     Then the metadata is valid JSON-LD
     And gsscogs/csv2rdf generates RDF
@@ -452,8 +452,8 @@ Scenario: Manually Overriding CSV-W's graph URI works.
     @prefix sd: <http://www.w3.org/ns/sparql-service-description#>.
     @prefix void: <http://rdfs.org/ns/void#>.
 
-    <http://gss-data.org.uk/graph/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity>
+    <http://gss-data.org.uk/graph2/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity>
         a sd:NamedGraph;
-        sd:name <http://gss-data.org.uk/graph/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity>;
+        sd:name <http://gss-data.org.uk/graph2/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity>;
         void:rootResource <http://gss-data.org.uk/data/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity#dataset>.
     """

--- a/features/csvw.feature
+++ b/features/csvw.feature
@@ -418,3 +418,42 @@ Scenario: A user wishes to specify a parent dimension for a locally defined data
           qb:codeList <http://gss-data.org.uk/data/gss_data/health/life-expectancy-in-newport#scheme/region> ;
           rdfs:subPropertyOf <http://purl.org/linked-data/sdmx/2009/dimension#refPeriod> .
     """
+
+  Scenario: CSV-W's Graph URI is automatically specified if not overridden.
+    Given a CSV file 'product-observations.csv'
+    And a JSON map file 'mapping-info.json'
+    And a dataset URI 'http://gss-data.org.uk/data/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity'
+    When I create a CSVW file from the mapping and CSV
+    Then the metadata is valid JSON-LD
+    And gsscogs/csv2rdf generates RDF
+    And the RDF should pass the Data Cube integrity constraints
+    And the RDF should contain
+    """
+    @prefix sd: <http://www.w3.org/ns/sparql-service-description#>.
+    @prefix void: <http://rdfs.org/ns/void#>.
+
+    <http://gss-data.org.uk/data/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity#graph>
+        a sd:NamedGraph;
+        sd:name <http://gss-data.org.uk/data/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity#graph>;
+        void:rootResource <http://gss-data.org.uk/data/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity#dataset>.
+    """
+
+Scenario: Manually Overriding CSV-W's graph URI works.
+    Given a CSV file 'product-observations.csv'
+    And a JSON map file 'mapping-info.json'
+    And a dataset URI 'http://gss-data.org.uk/data/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity'
+    And a containing graph URI 'http://gss-data.org.uk/graph/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity'
+    When I create a CSVW file from the mapping and CSV
+    Then the metadata is valid JSON-LD
+    And gsscogs/csv2rdf generates RDF
+    And the RDF should pass the Data Cube integrity constraints
+    And the RDF should contain
+    """
+    @prefix sd: <http://www.w3.org/ns/sparql-service-description#>.
+    @prefix void: <http://rdfs.org/ns/void#>.
+
+    <http://gss-data.org.uk/graph/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity>
+        a sd:NamedGraph;
+        sd:name <http://gss-data.org.uk/graph/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity>;
+        void:rootResource <http://gss-data.org.uk/data/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity#dataset>.
+    """

--- a/features/cubes.feature
+++ b/features/cubes.feature
@@ -38,3 +38,16 @@ Feature: Creating cubes
     And I specify a datacube named "test cube 3" with data "quarterly-balance-of-payments.csv" and a scrape using the seed "seed-temp-scrape-quarterly-balance-of-payments.json"
     And I specify a datacube named "test cube 4" with data "quarterly-balance-of-payments.csv" and a scrape using the seed "seed-temp-scrape-quarterly-balance-of-payments.json"
     Then the datacube outputs can be created
+
+
+  Scenario: Override of the containing Graph URI works
+    Given I want to create datacubes from the seed "seed-temp-scrape-quarterly-balance-of-payments.json"
+    And I add a cube "test cube 1" with data "quarterly-balance-of-payments.csv" and a scrape seed "seed-temp-scrape-quarterly-balance-of-payments.json" with override containing graph "http://containing-graph-uri"
+    Then the datacube outputs can be created
+    Then generate RDF from the n=0 cube's CSV-W output
+    And the RDF should contain
+    """
+    @prefix sd: <http://www.w3.org/ns/sparql-service-description#>.
+
+    <http://containing-graph-uri> a sd:NamedGraph.
+    """

--- a/features/fixtures/quarterly-balance-of-payments.csv
+++ b/features/fixtures/quarterly-balance-of-payments.csv
@@ -1,361 +1,361 @@
 Geography,Period,CDID,BOP Services,Flow Directions,Measure Type,Value,Unit
-K02000001,year/2018,MTN7,1+2,exports,GBP Total,5691.0,GBP (Million)
-K02000001,year/2019,MTN7,1+2,exports,GBP Total,6434.0,GBP (Million)
-K02000001,quarter/2018-Q2,MTN7,1+2,exports,GBP Total,1372.0,GBP (Million)
-K02000001,quarter/2018-Q3,MTN7,1+2,exports,GBP Total,1467.0,GBP (Million)
-K02000001,quarter/2018-Q4,MTN7,1+2,exports,GBP Total,1483.0,GBP (Million)
-K02000001,quarter/2019-Q1,MTN7,1+2,exports,GBP Total,1602.0,GBP (Million)
-K02000001,quarter/2019-Q2,MTN7,1+2,exports,GBP Total,1616.0,GBP (Million)
-K02000001,quarter/2019-Q3,MTN7,1+2,exports,GBP Total,1622.0,GBP (Million)
-K02000001,quarter/2019-Q4,MTN7,1+2,exports,GBP Total,1594.0,GBP (Million)
-K02000001,quarter/2020-Q1,MTN7,1+2,exports,GBP Total,1478.0,GBP (Million)
-K02000001,year/2018,FKOA,3,exports,GBP Total,29469.0,GBP (Million)
-K02000001,year/2019,FKOA,3,exports,GBP Total,31249.0,GBP (Million)
-K02000001,quarter/2018-Q2,FKOA,3,exports,GBP Total,7161.0,GBP (Million)
-K02000001,quarter/2018-Q3,FKOA,3,exports,GBP Total,7366.0,GBP (Million)
-K02000001,quarter/2018-Q4,FKOA,3,exports,GBP Total,7505.0,GBP (Million)
-K02000001,quarter/2019-Q1,FKOA,3,exports,GBP Total,7868.0,GBP (Million)
-K02000001,quarter/2019-Q2,FKOA,3,exports,GBP Total,7801.0,GBP (Million)
-K02000001,quarter/2019-Q3,FKOA,3,exports,GBP Total,7545.0,GBP (Million)
-K02000001,quarter/2019-Q4,FKOA,3,exports,GBP Total,8035.0,GBP (Million)
-K02000001,quarter/2020-Q1,FKOA,3,exports,GBP Total,7133.0,GBP (Million)
-K02000001,year/2018,FAPO,4,exports,GBP Total,36431.0,GBP (Million)
-K02000001,year/2019,FAPO,4,exports,GBP Total,39515.0,GBP (Million)
-K02000001,quarter/2018-Q2,FAPO,4,exports,GBP Total,8795.0,GBP (Million)
-K02000001,quarter/2018-Q3,FAPO,4,exports,GBP Total,8677.0,GBP (Million)
-K02000001,quarter/2018-Q4,FAPO,4,exports,GBP Total,9010.0,GBP (Million)
-K02000001,quarter/2019-Q1,FAPO,4,exports,GBP Total,9002.0,GBP (Million)
-K02000001,quarter/2019-Q2,FAPO,4,exports,GBP Total,9418.0,GBP (Million)
-K02000001,quarter/2019-Q3,FAPO,4,exports,GBP Total,10335.0,GBP (Million)
-K02000001,quarter/2019-Q4,FAPO,4,exports,GBP Total,10760.0,GBP (Million)
-K02000001,quarter/2020-Q1,FAPO,4,exports,GBP Total,6377.0,GBP (Million)
-K02000001,year/2018,FDSG,5,exports,GBP Total,2671.0,GBP (Million)
-K02000001,year/2019,FDSG,5,exports,GBP Total,2920.0,GBP (Million)
-K02000001,quarter/2018-Q2,FDSG,5,exports,GBP Total,592.0,GBP (Million)
-K02000001,quarter/2018-Q3,FDSG,5,exports,GBP Total,659.0,GBP (Million)
-K02000001,quarter/2018-Q4,FDSG,5,exports,GBP Total,727.0,GBP (Million)
-K02000001,quarter/2019-Q1,FDSG,5,exports,GBP Total,681.0,GBP (Million)
-K02000001,quarter/2019-Q2,FDSG,5,exports,GBP Total,766.0,GBP (Million)
-K02000001,quarter/2019-Q3,FDSG,5,exports,GBP Total,729.0,GBP (Million)
-K02000001,quarter/2019-Q4,FDSG,5,exports,GBP Total,744.0,GBP (Million)
-K02000001,quarter/2020-Q1,FDSG,5,exports,GBP Total,699.0,GBP (Million)
-K02000001,year/2018,FDTF,6,exports,GBP Total,19425.0,GBP (Million)
-K02000001,year/2019,FDTF,6,exports,GBP Total,20153.0,GBP (Million)
-K02000001,quarter/2018-Q2,FDTF,6,exports,GBP Total,4731.0,GBP (Million)
-K02000001,quarter/2018-Q3,FDTF,6,exports,GBP Total,5073.0,GBP (Million)
-K02000001,quarter/2018-Q4,FDTF,6,exports,GBP Total,4885.0,GBP (Million)
-K02000001,quarter/2019-Q1,FDTF,6,exports,GBP Total,4957.0,GBP (Million)
-K02000001,quarter/2019-Q2,FDTF,6,exports,GBP Total,5016.0,GBP (Million)
-K02000001,quarter/2019-Q3,FDTF,6,exports,GBP Total,5043.0,GBP (Million)
-K02000001,quarter/2019-Q4,FDTF,6,exports,GBP Total,5137.0,GBP (Million)
-K02000001,quarter/2020-Q1,FDTF,6,exports,GBP Total,5108.0,GBP (Million)
-K02000001,year/2018,FDYI,7,exports,GBP Total,63222.0,GBP (Million)
-K02000001,year/2019,FDYI,7,exports,GBP Total,63297.0,GBP (Million)
-K02000001,quarter/2018-Q2,FDYI,7,exports,GBP Total,16241.0,GBP (Million)
-K02000001,quarter/2018-Q3,FDYI,7,exports,GBP Total,15672.0,GBP (Million)
-K02000001,quarter/2018-Q4,FDYI,7,exports,GBP Total,15854.0,GBP (Million)
-K02000001,quarter/2019-Q1,FDYI,7,exports,GBP Total,15818.0,GBP (Million)
-K02000001,quarter/2019-Q2,FDYI,7,exports,GBP Total,14949.0,GBP (Million)
-K02000001,quarter/2019-Q3,FDYI,7,exports,GBP Total,16506.0,GBP (Million)
-K02000001,quarter/2019-Q4,FDYI,7,exports,GBP Total,16024.0,GBP (Million)
-K02000001,quarter/2020-Q1,FDYI,7,exports,GBP Total,16589.0,GBP (Million)
-K02000001,year/2018,FEBA,8,exports,GBP Total,19721.0,GBP (Million)
-K02000001,year/2019,FEBA,8,exports,GBP Total,19776.0,GBP (Million)
-K02000001,quarter/2018-Q2,FEBA,8,exports,GBP Total,4616.0,GBP (Million)
-K02000001,quarter/2018-Q3,FEBA,8,exports,GBP Total,4565.0,GBP (Million)
-K02000001,quarter/2018-Q4,FEBA,8,exports,GBP Total,6131.0,GBP (Million)
-K02000001,quarter/2019-Q1,FEBA,8,exports,GBP Total,4608.0,GBP (Million)
-K02000001,quarter/2019-Q2,FEBA,8,exports,GBP Total,5042.0,GBP (Million)
-K02000001,quarter/2019-Q3,FEBA,8,exports,GBP Total,4787.0,GBP (Million)
-K02000001,quarter/2019-Q4,FEBA,8,exports,GBP Total,5339.0,GBP (Million)
-K02000001,quarter/2020-Q1,FEBA,8,exports,GBP Total,4147.0,GBP (Million)
-K02000001,year/2018,FDYQ,9,exports,GBP Total,23960.0,GBP (Million)
-K02000001,year/2019,FDYQ,9,exports,GBP Total,23400.0,GBP (Million)
-K02000001,quarter/2018-Q2,FDYQ,9,exports,GBP Total,5784.0,GBP (Million)
-K02000001,quarter/2018-Q3,FDYQ,9,exports,GBP Total,6016.0,GBP (Million)
-K02000001,quarter/2018-Q4,FDYQ,9,exports,GBP Total,6249.0,GBP (Million)
-K02000001,quarter/2019-Q1,FDYQ,9,exports,GBP Total,5663.0,GBP (Million)
-K02000001,quarter/2019-Q2,FDYQ,9,exports,GBP Total,5757.0,GBP (Million)
-K02000001,quarter/2019-Q3,FDYQ,9,exports,GBP Total,6004.0,GBP (Million)
-K02000001,quarter/2019-Q4,FDYQ,9,exports,GBP Total,5976.0,GBP (Million)
-K02000001,quarter/2020-Q1,FDYQ,9,exports,GBP Total,5326.0,GBP (Million)
-K02000001,year/2018,FEHH,10,exports,GBP Total,98796.0,GBP (Million)
-K02000001,year/2019,FEHH,10,exports,GBP Total,113049.0,GBP (Million)
-K02000001,quarter/2018-Q2,FEHH,10,exports,GBP Total,23893.0,GBP (Million)
-K02000001,quarter/2018-Q3,FEHH,10,exports,GBP Total,25842.0,GBP (Million)
-K02000001,quarter/2018-Q4,FEHH,10,exports,GBP Total,26374.0,GBP (Million)
-K02000001,quarter/2019-Q1,FEHH,10,exports,GBP Total,27223.0,GBP (Million)
-K02000001,quarter/2019-Q2,FEHH,10,exports,GBP Total,28462.0,GBP (Million)
-K02000001,quarter/2019-Q3,FEHH,10,exports,GBP Total,29135.0,GBP (Million)
-K02000001,quarter/2019-Q4,FEHH,10,exports,GBP Total,28229.0,GBP (Million)
-K02000001,quarter/2020-Q1,FEHH,10,exports,GBP Total,28246.0,GBP (Million)
-K02000001,year/2018,FGXJ,11,exports,GBP Total,4584.0,GBP (Million)
-K02000001,year/2019,FGXJ,11,exports,GBP Total,4812.0,GBP (Million)
-K02000001,quarter/2018-Q2,FGXJ,11,exports,GBP Total,1161.0,GBP (Million)
-K02000001,quarter/2018-Q3,FGXJ,11,exports,GBP Total,1175.0,GBP (Million)
-K02000001,quarter/2018-Q4,FGXJ,11,exports,GBP Total,1197.0,GBP (Million)
-K02000001,quarter/2019-Q1,FGXJ,11,exports,GBP Total,1186.0,GBP (Million)
-K02000001,quarter/2019-Q2,FGXJ,11,exports,GBP Total,1046.0,GBP (Million)
-K02000001,quarter/2019-Q3,FGXJ,11,exports,GBP Total,1223.0,GBP (Million)
-K02000001,quarter/2019-Q4,FGXJ,11,exports,GBP Total,1357.0,GBP (Million)
-K02000001,quarter/2020-Q1,FGXJ,11,exports,GBP Total,1365.0,GBP (Million)
-K02000001,year/2018,FGZA,12,exports,GBP Total,2900.0,GBP (Million)
-K02000001,year/2019,FGZA,12,exports,GBP Total,3237.0,GBP (Million)
-K02000001,quarter/2018-Q2,FGZA,12,exports,GBP Total,733.0,GBP (Million)
-K02000001,quarter/2018-Q3,FGZA,12,exports,GBP Total,755.0,GBP (Million)
-K02000001,quarter/2018-Q4,FGZA,12,exports,GBP Total,686.0,GBP (Million)
-K02000001,quarter/2019-Q1,FGZA,12,exports,GBP Total,800.0,GBP (Million)
-K02000001,quarter/2019-Q2,FGZA,12,exports,GBP Total,784.0,GBP (Million)
-K02000001,quarter/2019-Q3,FGZA,12,exports,GBP Total,810.0,GBP (Million)
-K02000001,quarter/2019-Q4,FGZA,12,exports,GBP Total,843.0,GBP (Million)
-K02000001,quarter/2020-Q1,FGZA,12,exports,GBP Total,809.0,GBP (Million)
-K02000001,year/2018,IKBB,0,exports,GBP Total,306870.0,GBP (Million)
-K02000001,year/2019,IKBB,0,exports,GBP Total,327842.0,GBP (Million)
-K02000001,quarter/2018-Q2,IKBB,0,exports,GBP Total,75079.0,GBP (Million)
-K02000001,quarter/2018-Q3,IKBB,0,exports,GBP Total,77267.0,GBP (Million)
-K02000001,quarter/2018-Q4,IKBB,0,exports,GBP Total,80101.0,GBP (Million)
-K02000001,quarter/2019-Q1,IKBB,0,exports,GBP Total,79408.0,GBP (Million)
-K02000001,quarter/2019-Q2,IKBB,0,exports,GBP Total,80657.0,GBP (Million)
-K02000001,quarter/2019-Q3,IKBB,0,exports,GBP Total,83739.0,GBP (Million)
-K02000001,quarter/2019-Q4,IKBB,0,exports,GBP Total,84038.0,GBP (Million)
-K02000001,quarter/2020-Q1,IKBB,0,exports,GBP Total,77277.0,GBP (Million)
-K02000001,year/2018,MTN6,1+2,imports,GBP Total,2151.0,GBP (Million)
-K02000001,year/2019,MTN6,1+2,imports,GBP Total,2819.0,GBP (Million)
-K02000001,quarter/2018-Q2,MTN6,1+2,imports,GBP Total,442.0,GBP (Million)
-K02000001,quarter/2018-Q3,MTN6,1+2,imports,GBP Total,448.0,GBP (Million)
-K02000001,quarter/2018-Q4,MTN6,1+2,imports,GBP Total,725.0,GBP (Million)
-K02000001,quarter/2019-Q1,MTN6,1+2,imports,GBP Total,689.0,GBP (Million)
-K02000001,quarter/2019-Q2,MTN6,1+2,imports,GBP Total,692.0,GBP (Million)
-K02000001,quarter/2019-Q3,MTN6,1+2,imports,GBP Total,719.0,GBP (Million)
-K02000001,quarter/2019-Q4,MTN6,1+2,imports,GBP Total,719.0,GBP (Million)
-K02000001,quarter/2020-Q1,MTN6,1+2,imports,GBP Total,550.0,GBP (Million)
-K02000001,year/2018,FHME,3,imports,GBP Total,25524.0,GBP (Million)
-K02000001,year/2019,FHME,3,imports,GBP Total,25639.0,GBP (Million)
-K02000001,quarter/2018-Q2,FHME,3,imports,GBP Total,6291.0,GBP (Million)
-K02000001,quarter/2018-Q3,FHME,3,imports,GBP Total,6471.0,GBP (Million)
-K02000001,quarter/2018-Q4,FHME,3,imports,GBP Total,6276.0,GBP (Million)
-K02000001,quarter/2019-Q1,FHME,3,imports,GBP Total,6389.0,GBP (Million)
-K02000001,quarter/2019-Q2,FHME,3,imports,GBP Total,6426.0,GBP (Million)
-K02000001,quarter/2019-Q3,FHME,3,imports,GBP Total,6469.0,GBP (Million)
-K02000001,quarter/2019-Q4,FHME,3,imports,GBP Total,6355.0,GBP (Million)
-K02000001,quarter/2020-Q1,FHME,3,imports,GBP Total,6075.0,GBP (Million)
-K02000001,year/2018,APQL,4,imports,GBP Total,51742.0,GBP (Million)
-K02000001,year/2019,APQL,4,imports,GBP Total,55619.0,GBP (Million)
-K02000001,quarter/2018-Q2,APQL,4,imports,GBP Total,12671.0,GBP (Million)
-K02000001,quarter/2018-Q3,APQL,4,imports,GBP Total,13063.0,GBP (Million)
-K02000001,quarter/2018-Q4,APQL,4,imports,GBP Total,13112.0,GBP (Million)
-K02000001,quarter/2019-Q1,APQL,4,imports,GBP Total,13103.0,GBP (Million)
-K02000001,quarter/2019-Q2,APQL,4,imports,GBP Total,13567.0,GBP (Million)
-K02000001,quarter/2019-Q3,APQL,4,imports,GBP Total,14314.0,GBP (Million)
-K02000001,quarter/2019-Q4,APQL,4,imports,GBP Total,14635.0,GBP (Million)
-K02000001,quarter/2020-Q1,APQL,4,imports,GBP Total,10872.0,GBP (Million)
-K02000001,year/2018,FIOU,5,imports,GBP Total,2090.0,GBP (Million)
-K02000001,year/2019,FIOU,5,imports,GBP Total,2832.0,GBP (Million)
-K02000001,quarter/2018-Q2,FIOU,5,imports,GBP Total,465.0,GBP (Million)
-K02000001,quarter/2018-Q3,FIOU,5,imports,GBP Total,536.0,GBP (Million)
-K02000001,quarter/2018-Q4,FIOU,5,imports,GBP Total,590.0,GBP (Million)
-K02000001,quarter/2019-Q1,FIOU,5,imports,GBP Total,604.0,GBP (Million)
-K02000001,quarter/2019-Q2,FIOU,5,imports,GBP Total,593.0,GBP (Million)
-K02000001,quarter/2019-Q3,FIOU,5,imports,GBP Total,666.0,GBP (Million)
-K02000001,quarter/2019-Q4,FIOU,5,imports,GBP Total,969.0,GBP (Million)
-K02000001,quarter/2020-Q1,FIOU,5,imports,GBP Total,828.0,GBP (Million)
-K02000001,year/2018,FIPT,6,imports,GBP Total,3095.0,GBP (Million)
-K02000001,year/2019,FIPT,6,imports,GBP Total,3115.0,GBP (Million)
-K02000001,quarter/2018-Q2,FIPT,6,imports,GBP Total,734.0,GBP (Million)
-K02000001,quarter/2018-Q3,FIPT,6,imports,GBP Total,771.0,GBP (Million)
-K02000001,quarter/2018-Q4,FIPT,6,imports,GBP Total,857.0,GBP (Million)
-K02000001,quarter/2019-Q1,FIPT,6,imports,GBP Total,797.0,GBP (Million)
-K02000001,quarter/2019-Q2,FIPT,6,imports,GBP Total,739.0,GBP (Million)
-K02000001,quarter/2019-Q3,FIPT,6,imports,GBP Total,773.0,GBP (Million)
-K02000001,quarter/2019-Q4,FIPT,6,imports,GBP Total,806.0,GBP (Million)
-K02000001,quarter/2020-Q1,FIPT,6,imports,GBP Total,694.0,GBP (Million)
-K02000001,year/2018,FITY,7,imports,GBP Total,17017.0,GBP (Million)
-K02000001,year/2019,FITY,7,imports,GBP Total,19673.0,GBP (Million)
-K02000001,quarter/2018-Q2,FITY,7,imports,GBP Total,4057.0,GBP (Million)
-K02000001,quarter/2018-Q3,FITY,7,imports,GBP Total,4274.0,GBP (Million)
-K02000001,quarter/2018-Q4,FITY,7,imports,GBP Total,4805.0,GBP (Million)
-K02000001,quarter/2019-Q1,FITY,7,imports,GBP Total,4825.0,GBP (Million)
-K02000001,quarter/2019-Q2,FITY,7,imports,GBP Total,5022.0,GBP (Million)
-K02000001,quarter/2019-Q3,FITY,7,imports,GBP Total,5083.0,GBP (Million)
-K02000001,quarter/2019-Q4,FITY,7,imports,GBP Total,4743.0,GBP (Million)
-K02000001,quarter/2020-Q1,FITY,7,imports,GBP Total,4710.0,GBP (Million)
-K02000001,year/2018,FIVX,8,imports,GBP Total,10860.0,GBP (Million)
-K02000001,year/2019,FIVX,8,imports,GBP Total,13269.0,GBP (Million)
-K02000001,quarter/2018-Q2,FIVX,8,imports,GBP Total,2630.0,GBP (Million)
-K02000001,quarter/2018-Q3,FIVX,8,imports,GBP Total,2708.0,GBP (Million)
-K02000001,quarter/2018-Q4,FIVX,8,imports,GBP Total,2928.0,GBP (Million)
-K02000001,quarter/2019-Q1,FIVX,8,imports,GBP Total,3132.0,GBP (Million)
-K02000001,quarter/2019-Q2,FIVX,8,imports,GBP Total,3343.0,GBP (Million)
-K02000001,quarter/2019-Q3,FIVX,8,imports,GBP Total,3427.0,GBP (Million)
-K02000001,quarter/2019-Q4,FIVX,8,imports,GBP Total,3367.0,GBP (Million)
-K02000001,quarter/2020-Q1,FIVX,8,imports,GBP Total,2644.0,GBP (Million)
-K02000001,year/2018,FIUG,9,imports,GBP Total,10751.0,GBP (Million)
-K02000001,year/2019,FIUG,9,imports,GBP Total,10498.0,GBP (Million)
-K02000001,quarter/2018-Q2,FIUG,9,imports,GBP Total,2633.0,GBP (Million)
-K02000001,quarter/2018-Q3,FIUG,9,imports,GBP Total,2586.0,GBP (Million)
-K02000001,quarter/2018-Q4,FIUG,9,imports,GBP Total,2767.0,GBP (Million)
-K02000001,quarter/2019-Q1,FIUG,9,imports,GBP Total,2568.0,GBP (Million)
-K02000001,quarter/2019-Q2,FIUG,9,imports,GBP Total,2733.0,GBP (Million)
-K02000001,quarter/2019-Q3,FIUG,9,imports,GBP Total,2718.0,GBP (Million)
-K02000001,quarter/2019-Q4,FIUG,9,imports,GBP Total,2479.0,GBP (Million)
-K02000001,quarter/2020-Q1,FIUG,9,imports,GBP Total,2389.0,GBP (Million)
-K02000001,year/2018,FIWF,10,imports,GBP Total,66285.0,GBP (Million)
-K02000001,year/2019,FIWF,10,imports,GBP Total,80831.0,GBP (Million)
-K02000001,quarter/2018-Q2,FIWF,10,imports,GBP Total,16259.0,GBP (Million)
-K02000001,quarter/2018-Q3,FIWF,10,imports,GBP Total,16232.0,GBP (Million)
-K02000001,quarter/2018-Q4,FIWF,10,imports,GBP Total,18567.0,GBP (Million)
-K02000001,quarter/2019-Q1,FIWF,10,imports,GBP Total,17872.0,GBP (Million)
-K02000001,quarter/2019-Q2,FIWF,10,imports,GBP Total,18560.0,GBP (Million)
-K02000001,quarter/2019-Q3,FIWF,10,imports,GBP Total,20283.0,GBP (Million)
-K02000001,quarter/2019-Q4,FIWF,10,imports,GBP Total,24116.0,GBP (Million)
-K02000001,quarter/2020-Q1,FIWF,10,imports,GBP Total,18338.0,GBP (Million)
-K02000001,year/2018,FLQJ,11,imports,GBP Total,4095.0,GBP (Million)
-K02000001,year/2019,FLQJ,11,imports,GBP Total,4436.0,GBP (Million)
-K02000001,quarter/2018-Q2,FLQJ,11,imports,GBP Total,988.0,GBP (Million)
-K02000001,quarter/2018-Q3,FLQJ,11,imports,GBP Total,1098.0,GBP (Million)
-K02000001,quarter/2018-Q4,FLQJ,11,imports,GBP Total,1036.0,GBP (Million)
-K02000001,quarter/2019-Q1,FLQJ,11,imports,GBP Total,1041.0,GBP (Million)
-K02000001,quarter/2019-Q2,FLQJ,11,imports,GBP Total,1076.0,GBP (Million)
-K02000001,quarter/2019-Q3,FLQJ,11,imports,GBP Total,1175.0,GBP (Million)
-K02000001,quarter/2019-Q4,FLQJ,11,imports,GBP Total,1144.0,GBP (Million)
-K02000001,quarter/2020-Q1,FLQJ,11,imports,GBP Total,1169.0,GBP (Million)
-K02000001,year/2018,FLSA,12,imports,GBP Total,3682.0,GBP (Million)
-K02000001,year/2019,FLSA,12,imports,GBP Total,3641.0,GBP (Million)
-K02000001,quarter/2018-Q2,FLSA,12,imports,GBP Total,937.0,GBP (Million)
-K02000001,quarter/2018-Q3,FLSA,12,imports,GBP Total,857.0,GBP (Million)
-K02000001,quarter/2018-Q4,FLSA,12,imports,GBP Total,962.0,GBP (Million)
-K02000001,quarter/2019-Q1,FLSA,12,imports,GBP Total,921.0,GBP (Million)
-K02000001,quarter/2019-Q2,FLSA,12,imports,GBP Total,839.0,GBP (Million)
-K02000001,quarter/2019-Q3,FLSA,12,imports,GBP Total,958.0,GBP (Million)
-K02000001,quarter/2019-Q4,FLSA,12,imports,GBP Total,923.0,GBP (Million)
-K02000001,quarter/2020-Q1,FLSA,12,imports,GBP Total,894.0,GBP (Million)
-K02000001,year/2018,IKBC,0,imports,GBP Total,197292.0,GBP (Million)
-K02000001,year/2019,IKBC,0,imports,GBP Total,222372.0,GBP (Million)
-K02000001,quarter/2018-Q2,IKBC,0,imports,GBP Total,48107.0,GBP (Million)
-K02000001,quarter/2018-Q3,IKBC,0,imports,GBP Total,49044.0,GBP (Million)
-K02000001,quarter/2018-Q4,IKBC,0,imports,GBP Total,52625.0,GBP (Million)
-K02000001,quarter/2019-Q1,IKBC,0,imports,GBP Total,51941.0,GBP (Million)
-K02000001,quarter/2019-Q2,IKBC,0,imports,GBP Total,53590.0,GBP (Million)
-K02000001,quarter/2019-Q3,IKBC,0,imports,GBP Total,56585.0,GBP (Million)
-K02000001,quarter/2019-Q4,IKBC,0,imports,GBP Total,60256.0,GBP (Million)
-K02000001,quarter/2020-Q1,IKBC,0,imports,GBP Total,49163.0,GBP (Million)
-K02000001,year/2018,MTN8,1+2,balances,GBP Total,3540.0,GBP (Million)
-K02000001,year/2019,MTN8,1+2,balances,GBP Total,3615.0,GBP (Million)
-K02000001,quarter/2018-Q2,MTN8,1+2,balances,GBP Total,930.0,GBP (Million)
-K02000001,quarter/2018-Q3,MTN8,1+2,balances,GBP Total,1019.0,GBP (Million)
-K02000001,quarter/2018-Q4,MTN8,1+2,balances,GBP Total,758.0,GBP (Million)
-K02000001,quarter/2019-Q1,MTN8,1+2,balances,GBP Total,913.0,GBP (Million)
-K02000001,quarter/2019-Q2,MTN8,1+2,balances,GBP Total,924.0,GBP (Million)
-K02000001,quarter/2019-Q3,MTN8,1+2,balances,GBP Total,903.0,GBP (Million)
-K02000001,quarter/2019-Q4,MTN8,1+2,balances,GBP Total,875.0,GBP (Million)
-K02000001,quarter/2020-Q1,MTN8,1+2,balances,GBP Total,928.0,GBP (Million)
-K02000001,year/2018,FLYS,3,balances,GBP Total,3945.0,GBP (Million)
-K02000001,year/2019,FLYS,3,balances,GBP Total,5610.0,GBP (Million)
-K02000001,quarter/2018-Q2,FLYS,3,balances,GBP Total,870.0,GBP (Million)
-K02000001,quarter/2018-Q3,FLYS,3,balances,GBP Total,895.0,GBP (Million)
-K02000001,quarter/2018-Q4,FLYS,3,balances,GBP Total,1229.0,GBP (Million)
-K02000001,quarter/2019-Q1,FLYS,3,balances,GBP Total,1479.0,GBP (Million)
-K02000001,quarter/2019-Q2,FLYS,3,balances,GBP Total,1375.0,GBP (Million)
-K02000001,quarter/2019-Q3,FLYS,3,balances,GBP Total,1076.0,GBP (Million)
-K02000001,quarter/2019-Q4,FLYS,3,balances,GBP Total,1680.0,GBP (Million)
-K02000001,quarter/2020-Q1,FLYS,3,balances,GBP Total,1058.0,GBP (Million)
-K02000001,year/2018,FNGY,4,balances,GBP Total,-15311.0,GBP (Million)
-K02000001,year/2019,FNGY,4,balances,GBP Total,-16104.0,GBP (Million)
-K02000001,quarter/2018-Q2,FNGY,4,balances,GBP Total,-3876.0,GBP (Million)
-K02000001,quarter/2018-Q3,FNGY,4,balances,GBP Total,-4386.0,GBP (Million)
-K02000001,quarter/2018-Q4,FNGY,4,balances,GBP Total,-4102.0,GBP (Million)
-K02000001,quarter/2019-Q1,FNGY,4,balances,GBP Total,-4101.0,GBP (Million)
-K02000001,quarter/2019-Q2,FNGY,4,balances,GBP Total,-4149.0,GBP (Million)
-K02000001,quarter/2019-Q3,FNGY,4,balances,GBP Total,-3979.0,GBP (Million)
-K02000001,quarter/2019-Q4,FNGY,4,balances,GBP Total,-3875.0,GBP (Million)
-K02000001,quarter/2020-Q1,FNGY,4,balances,GBP Total,-4495.0,GBP (Million)
-K02000001,year/2018,FNJM,5,balances,GBP Total,581.0,GBP (Million)
-K02000001,year/2019,FNJM,5,balances,GBP Total,88.0,GBP (Million)
-K02000001,quarter/2018-Q2,FNJM,5,balances,GBP Total,127.0,GBP (Million)
-K02000001,quarter/2018-Q3,FNJM,5,balances,GBP Total,123.0,GBP (Million)
-K02000001,quarter/2018-Q4,FNJM,5,balances,GBP Total,137.0,GBP (Million)
-K02000001,quarter/2019-Q1,FNJM,5,balances,GBP Total,77.0,GBP (Million)
-K02000001,quarter/2019-Q2,FNJM,5,balances,GBP Total,173.0,GBP (Million)
-K02000001,quarter/2019-Q3,FNJM,5,balances,GBP Total,63.0,GBP (Million)
-K02000001,quarter/2019-Q4,FNJM,5,balances,GBP Total,-225.0,GBP (Million)
-K02000001,quarter/2020-Q1,FNJM,5,balances,GBP Total,-129.0,GBP (Million)
-K02000001,year/2018,FNKF,6,balances,GBP Total,16330.0,GBP (Million)
-K02000001,year/2019,FNKF,6,balances,GBP Total,17038.0,GBP (Million)
-K02000001,quarter/2018-Q2,FNKF,6,balances,GBP Total,3997.0,GBP (Million)
-K02000001,quarter/2018-Q3,FNKF,6,balances,GBP Total,4302.0,GBP (Million)
-K02000001,quarter/2018-Q4,FNKF,6,balances,GBP Total,4028.0,GBP (Million)
-K02000001,quarter/2019-Q1,FNKF,6,balances,GBP Total,4160.0,GBP (Million)
-K02000001,quarter/2019-Q2,FNKF,6,balances,GBP Total,4277.0,GBP (Million)
-K02000001,quarter/2019-Q3,FNKF,6,balances,GBP Total,4270.0,GBP (Million)
-K02000001,quarter/2019-Q4,FNKF,6,balances,GBP Total,4331.0,GBP (Million)
-K02000001,quarter/2020-Q1,FNKF,6,balances,GBP Total,4414.0,GBP (Million)
-K02000001,year/2018,FNLQ,7,balances,GBP Total,46205.0,GBP (Million)
-K02000001,year/2019,FNLQ,7,balances,GBP Total,43624.0,GBP (Million)
-K02000001,quarter/2018-Q2,FNLQ,7,balances,GBP Total,12184.0,GBP (Million)
-K02000001,quarter/2018-Q3,FNLQ,7,balances,GBP Total,11398.0,GBP (Million)
-K02000001,quarter/2018-Q4,FNLQ,7,balances,GBP Total,11049.0,GBP (Million)
-K02000001,quarter/2019-Q1,FNLQ,7,balances,GBP Total,10993.0,GBP (Million)
-K02000001,quarter/2019-Q2,FNLQ,7,balances,GBP Total,9927.0,GBP (Million)
-K02000001,quarter/2019-Q3,FNLQ,7,balances,GBP Total,11423.0,GBP (Million)
-K02000001,quarter/2019-Q4,FNLQ,7,balances,GBP Total,11281.0,GBP (Million)
-K02000001,quarter/2020-Q1,FNLQ,7,balances,GBP Total,11879.0,GBP (Million)
-K02000001,year/2018,FNMR,8,balances,GBP Total,8861.0,GBP (Million)
-K02000001,year/2019,FNMR,8,balances,GBP Total,6507.0,GBP (Million)
-K02000001,quarter/2018-Q2,FNMR,8,balances,GBP Total,1986.0,GBP (Million)
-K02000001,quarter/2018-Q3,FNMR,8,balances,GBP Total,1857.0,GBP (Million)
-K02000001,quarter/2018-Q4,FNMR,8,balances,GBP Total,3203.0,GBP (Million)
-K02000001,quarter/2019-Q1,FNMR,8,balances,GBP Total,1476.0,GBP (Million)
-K02000001,quarter/2019-Q2,FNMR,8,balances,GBP Total,1699.0,GBP (Million)
-K02000001,quarter/2019-Q3,FNMR,8,balances,GBP Total,1360.0,GBP (Million)
-K02000001,quarter/2019-Q4,FNMR,8,balances,GBP Total,1972.0,GBP (Million)
-K02000001,quarter/2020-Q1,FNMR,8,balances,GBP Total,1503.0,GBP (Million)
-K02000001,year/2018,FNLY,9,balances,GBP Total,13209.0,GBP (Million)
-K02000001,year/2019,FNLY,9,balances,GBP Total,12902.0,GBP (Million)
-K02000001,quarter/2018-Q2,FNLY,9,balances,GBP Total,3151.0,GBP (Million)
-K02000001,quarter/2018-Q3,FNLY,9,balances,GBP Total,3430.0,GBP (Million)
-K02000001,quarter/2018-Q4,FNLY,9,balances,GBP Total,3482.0,GBP (Million)
-K02000001,quarter/2019-Q1,FNLY,9,balances,GBP Total,3095.0,GBP (Million)
-K02000001,quarter/2019-Q2,FNLY,9,balances,GBP Total,3024.0,GBP (Million)
-K02000001,quarter/2019-Q3,FNLY,9,balances,GBP Total,3286.0,GBP (Million)
-K02000001,quarter/2019-Q4,FNLY,9,balances,GBP Total,3497.0,GBP (Million)
-K02000001,quarter/2020-Q1,FNLY,9,balances,GBP Total,2937.0,GBP (Million)
-K02000001,year/2018,FNMZ,10,balances,GBP Total,32511.0,GBP (Million)
-K02000001,year/2019,FNMZ,10,balances,GBP Total,32218.0,GBP (Million)
-K02000001,quarter/2018-Q2,FNMZ,10,balances,GBP Total,7634.0,GBP (Million)
-K02000001,quarter/2018-Q3,FNMZ,10,balances,GBP Total,9610.0,GBP (Million)
-K02000001,quarter/2018-Q4,FNMZ,10,balances,GBP Total,7807.0,GBP (Million)
-K02000001,quarter/2019-Q1,FNMZ,10,balances,GBP Total,9351.0,GBP (Million)
-K02000001,quarter/2019-Q2,FNMZ,10,balances,GBP Total,9902.0,GBP (Million)
-K02000001,quarter/2019-Q3,FNMZ,10,balances,GBP Total,8852.0,GBP (Million)
-K02000001,quarter/2019-Q4,FNMZ,10,balances,GBP Total,4113.0,GBP (Million)
-K02000001,quarter/2020-Q1,FNMZ,10,balances,GBP Total,9908.0,GBP (Million)
-K02000001,year/2018,FNRB,11,balances,GBP Total,489.0,GBP (Million)
-K02000001,year/2019,FNRB,11,balances,GBP Total,376.0,GBP (Million)
-K02000001,quarter/2018-Q2,FNRB,11,balances,GBP Total,173.0,GBP (Million)
-K02000001,quarter/2018-Q3,FNRB,11,balances,GBP Total,77.0,GBP (Million)
-K02000001,quarter/2018-Q4,FNRB,11,balances,GBP Total,161.0,GBP (Million)
-K02000001,quarter/2019-Q1,FNRB,11,balances,GBP Total,145.0,GBP (Million)
-K02000001,quarter/2019-Q2,FNRB,11,balances,GBP Total,-30.0,GBP (Million)
-K02000001,quarter/2019-Q3,FNRB,11,balances,GBP Total,48.0,GBP (Million)
-K02000001,quarter/2019-Q4,FNRB,11,balances,GBP Total,213.0,GBP (Million)
-K02000001,quarter/2020-Q1,FNRB,11,balances,GBP Total,196.0,GBP (Million)
-K02000001,year/2018,FNRU,12,balances,GBP Total,-782.0,GBP (Million)
-K02000001,year/2019,FNRU,12,balances,GBP Total,-404.0,GBP (Million)
-K02000001,quarter/2018-Q2,FNRU,12,balances,GBP Total,-204.0,GBP (Million)
-K02000001,quarter/2018-Q3,FNRU,12,balances,GBP Total,-102.0,GBP (Million)
-K02000001,quarter/2018-Q4,FNRU,12,balances,GBP Total,-276.0,GBP (Million)
-K02000001,quarter/2019-Q1,FNRU,12,balances,GBP Total,-121.0,GBP (Million)
-K02000001,quarter/2019-Q2,FNRU,12,balances,GBP Total,-55.0,GBP (Million)
-K02000001,quarter/2019-Q3,FNRU,12,balances,GBP Total,-148.0,GBP (Million)
-K02000001,quarter/2019-Q4,FNRU,12,balances,GBP Total,-80.0,GBP (Million)
-K02000001,quarter/2020-Q1,FNRU,12,balances,GBP Total,-85.0,GBP (Million)
-K02000001,year/2018,IKBD,0,balances,GBP Total,109578.0,GBP (Million)
-K02000001,year/2019,IKBD,0,balances,GBP Total,105470.0,GBP (Million)
-K02000001,quarter/2018-Q2,IKBD,0,balances,GBP Total,26972.0,GBP (Million)
-K02000001,quarter/2018-Q3,IKBD,0,balances,GBP Total,28223.0,GBP (Million)
-K02000001,quarter/2018-Q4,IKBD,0,balances,GBP Total,27476.0,GBP (Million)
-K02000001,quarter/2019-Q1,IKBD,0,balances,GBP Total,27467.0,GBP (Million)
-K02000001,quarter/2019-Q2,IKBD,0,balances,GBP Total,27067.0,GBP (Million)
-K02000001,quarter/2019-Q3,IKBD,0,balances,GBP Total,27154.0,GBP (Million)
-K02000001,quarter/2019-Q4,IKBD,0,balances,GBP Total,23782.0,GBP (Million)
-K02000001,quarter/2020-Q1,IKBD,0,balances,GBP Total,28114.0,GBP (Million)
+K02000001,year/2018,MTN7,1+2,exports,gbp-total,5691.0,gbp-million
+K02000001,year/2019,MTN7,1+2,exports,gbp-total,6434.0,gbp-million
+K02000001,quarter/2018-Q2,MTN7,1+2,exports,gbp-total,1372.0,gbp-million
+K02000001,quarter/2018-Q3,MTN7,1+2,exports,gbp-total,1467.0,gbp-million
+K02000001,quarter/2018-Q4,MTN7,1+2,exports,gbp-total,1483.0,gbp-million
+K02000001,quarter/2019-Q1,MTN7,1+2,exports,gbp-total,1602.0,gbp-million
+K02000001,quarter/2019-Q2,MTN7,1+2,exports,gbp-total,1616.0,gbp-million
+K02000001,quarter/2019-Q3,MTN7,1+2,exports,gbp-total,1622.0,gbp-million
+K02000001,quarter/2019-Q4,MTN7,1+2,exports,gbp-total,1594.0,gbp-million
+K02000001,quarter/2020-Q1,MTN7,1+2,exports,gbp-total,1478.0,gbp-million
+K02000001,year/2018,FKOA,3,exports,gbp-total,29469.0,gbp-million
+K02000001,year/2019,FKOA,3,exports,gbp-total,31249.0,gbp-million
+K02000001,quarter/2018-Q2,FKOA,3,exports,gbp-total,7161.0,gbp-million
+K02000001,quarter/2018-Q3,FKOA,3,exports,gbp-total,7366.0,gbp-million
+K02000001,quarter/2018-Q4,FKOA,3,exports,gbp-total,7505.0,gbp-million
+K02000001,quarter/2019-Q1,FKOA,3,exports,gbp-total,7868.0,gbp-million
+K02000001,quarter/2019-Q2,FKOA,3,exports,gbp-total,7801.0,gbp-million
+K02000001,quarter/2019-Q3,FKOA,3,exports,gbp-total,7545.0,gbp-million
+K02000001,quarter/2019-Q4,FKOA,3,exports,gbp-total,8035.0,gbp-million
+K02000001,quarter/2020-Q1,FKOA,3,exports,gbp-total,7133.0,gbp-million
+K02000001,year/2018,FAPO,4,exports,gbp-total,36431.0,gbp-million
+K02000001,year/2019,FAPO,4,exports,gbp-total,39515.0,gbp-million
+K02000001,quarter/2018-Q2,FAPO,4,exports,gbp-total,8795.0,gbp-million
+K02000001,quarter/2018-Q3,FAPO,4,exports,gbp-total,8677.0,gbp-million
+K02000001,quarter/2018-Q4,FAPO,4,exports,gbp-total,9010.0,gbp-million
+K02000001,quarter/2019-Q1,FAPO,4,exports,gbp-total,9002.0,gbp-million
+K02000001,quarter/2019-Q2,FAPO,4,exports,gbp-total,9418.0,gbp-million
+K02000001,quarter/2019-Q3,FAPO,4,exports,gbp-total,10335.0,gbp-million
+K02000001,quarter/2019-Q4,FAPO,4,exports,gbp-total,10760.0,gbp-million
+K02000001,quarter/2020-Q1,FAPO,4,exports,gbp-total,6377.0,gbp-million
+K02000001,year/2018,FDSG,5,exports,gbp-total,2671.0,gbp-million
+K02000001,year/2019,FDSG,5,exports,gbp-total,2920.0,gbp-million
+K02000001,quarter/2018-Q2,FDSG,5,exports,gbp-total,592.0,gbp-million
+K02000001,quarter/2018-Q3,FDSG,5,exports,gbp-total,659.0,gbp-million
+K02000001,quarter/2018-Q4,FDSG,5,exports,gbp-total,727.0,gbp-million
+K02000001,quarter/2019-Q1,FDSG,5,exports,gbp-total,681.0,gbp-million
+K02000001,quarter/2019-Q2,FDSG,5,exports,gbp-total,766.0,gbp-million
+K02000001,quarter/2019-Q3,FDSG,5,exports,gbp-total,729.0,gbp-million
+K02000001,quarter/2019-Q4,FDSG,5,exports,gbp-total,744.0,gbp-million
+K02000001,quarter/2020-Q1,FDSG,5,exports,gbp-total,699.0,gbp-million
+K02000001,year/2018,FDTF,6,exports,gbp-total,19425.0,gbp-million
+K02000001,year/2019,FDTF,6,exports,gbp-total,20153.0,gbp-million
+K02000001,quarter/2018-Q2,FDTF,6,exports,gbp-total,4731.0,gbp-million
+K02000001,quarter/2018-Q3,FDTF,6,exports,gbp-total,5073.0,gbp-million
+K02000001,quarter/2018-Q4,FDTF,6,exports,gbp-total,4885.0,gbp-million
+K02000001,quarter/2019-Q1,FDTF,6,exports,gbp-total,4957.0,gbp-million
+K02000001,quarter/2019-Q2,FDTF,6,exports,gbp-total,5016.0,gbp-million
+K02000001,quarter/2019-Q3,FDTF,6,exports,gbp-total,5043.0,gbp-million
+K02000001,quarter/2019-Q4,FDTF,6,exports,gbp-total,5137.0,gbp-million
+K02000001,quarter/2020-Q1,FDTF,6,exports,gbp-total,5108.0,gbp-million
+K02000001,year/2018,FDYI,7,exports,gbp-total,63222.0,gbp-million
+K02000001,year/2019,FDYI,7,exports,gbp-total,63297.0,gbp-million
+K02000001,quarter/2018-Q2,FDYI,7,exports,gbp-total,16241.0,gbp-million
+K02000001,quarter/2018-Q3,FDYI,7,exports,gbp-total,15672.0,gbp-million
+K02000001,quarter/2018-Q4,FDYI,7,exports,gbp-total,15854.0,gbp-million
+K02000001,quarter/2019-Q1,FDYI,7,exports,gbp-total,15818.0,gbp-million
+K02000001,quarter/2019-Q2,FDYI,7,exports,gbp-total,14949.0,gbp-million
+K02000001,quarter/2019-Q3,FDYI,7,exports,gbp-total,16506.0,gbp-million
+K02000001,quarter/2019-Q4,FDYI,7,exports,gbp-total,16024.0,gbp-million
+K02000001,quarter/2020-Q1,FDYI,7,exports,gbp-total,16589.0,gbp-million
+K02000001,year/2018,FEBA,8,exports,gbp-total,19721.0,gbp-million
+K02000001,year/2019,FEBA,8,exports,gbp-total,19776.0,gbp-million
+K02000001,quarter/2018-Q2,FEBA,8,exports,gbp-total,4616.0,gbp-million
+K02000001,quarter/2018-Q3,FEBA,8,exports,gbp-total,4565.0,gbp-million
+K02000001,quarter/2018-Q4,FEBA,8,exports,gbp-total,6131.0,gbp-million
+K02000001,quarter/2019-Q1,FEBA,8,exports,gbp-total,4608.0,gbp-million
+K02000001,quarter/2019-Q2,FEBA,8,exports,gbp-total,5042.0,gbp-million
+K02000001,quarter/2019-Q3,FEBA,8,exports,gbp-total,4787.0,gbp-million
+K02000001,quarter/2019-Q4,FEBA,8,exports,gbp-total,5339.0,gbp-million
+K02000001,quarter/2020-Q1,FEBA,8,exports,gbp-total,4147.0,gbp-million
+K02000001,year/2018,FDYQ,9,exports,gbp-total,23960.0,gbp-million
+K02000001,year/2019,FDYQ,9,exports,gbp-total,23400.0,gbp-million
+K02000001,quarter/2018-Q2,FDYQ,9,exports,gbp-total,5784.0,gbp-million
+K02000001,quarter/2018-Q3,FDYQ,9,exports,gbp-total,6016.0,gbp-million
+K02000001,quarter/2018-Q4,FDYQ,9,exports,gbp-total,6249.0,gbp-million
+K02000001,quarter/2019-Q1,FDYQ,9,exports,gbp-total,5663.0,gbp-million
+K02000001,quarter/2019-Q2,FDYQ,9,exports,gbp-total,5757.0,gbp-million
+K02000001,quarter/2019-Q3,FDYQ,9,exports,gbp-total,6004.0,gbp-million
+K02000001,quarter/2019-Q4,FDYQ,9,exports,gbp-total,5976.0,gbp-million
+K02000001,quarter/2020-Q1,FDYQ,9,exports,gbp-total,5326.0,gbp-million
+K02000001,year/2018,FEHH,10,exports,gbp-total,98796.0,gbp-million
+K02000001,year/2019,FEHH,10,exports,gbp-total,113049.0,gbp-million
+K02000001,quarter/2018-Q2,FEHH,10,exports,gbp-total,23893.0,gbp-million
+K02000001,quarter/2018-Q3,FEHH,10,exports,gbp-total,25842.0,gbp-million
+K02000001,quarter/2018-Q4,FEHH,10,exports,gbp-total,26374.0,gbp-million
+K02000001,quarter/2019-Q1,FEHH,10,exports,gbp-total,27223.0,gbp-million
+K02000001,quarter/2019-Q2,FEHH,10,exports,gbp-total,28462.0,gbp-million
+K02000001,quarter/2019-Q3,FEHH,10,exports,gbp-total,29135.0,gbp-million
+K02000001,quarter/2019-Q4,FEHH,10,exports,gbp-total,28229.0,gbp-million
+K02000001,quarter/2020-Q1,FEHH,10,exports,gbp-total,28246.0,gbp-million
+K02000001,year/2018,FGXJ,11,exports,gbp-total,4584.0,gbp-million
+K02000001,year/2019,FGXJ,11,exports,gbp-total,4812.0,gbp-million
+K02000001,quarter/2018-Q2,FGXJ,11,exports,gbp-total,1161.0,gbp-million
+K02000001,quarter/2018-Q3,FGXJ,11,exports,gbp-total,1175.0,gbp-million
+K02000001,quarter/2018-Q4,FGXJ,11,exports,gbp-total,1197.0,gbp-million
+K02000001,quarter/2019-Q1,FGXJ,11,exports,gbp-total,1186.0,gbp-million
+K02000001,quarter/2019-Q2,FGXJ,11,exports,gbp-total,1046.0,gbp-million
+K02000001,quarter/2019-Q3,FGXJ,11,exports,gbp-total,1223.0,gbp-million
+K02000001,quarter/2019-Q4,FGXJ,11,exports,gbp-total,1357.0,gbp-million
+K02000001,quarter/2020-Q1,FGXJ,11,exports,gbp-total,1365.0,gbp-million
+K02000001,year/2018,FGZA,12,exports,gbp-total,2900.0,gbp-million
+K02000001,year/2019,FGZA,12,exports,gbp-total,3237.0,gbp-million
+K02000001,quarter/2018-Q2,FGZA,12,exports,gbp-total,733.0,gbp-million
+K02000001,quarter/2018-Q3,FGZA,12,exports,gbp-total,755.0,gbp-million
+K02000001,quarter/2018-Q4,FGZA,12,exports,gbp-total,686.0,gbp-million
+K02000001,quarter/2019-Q1,FGZA,12,exports,gbp-total,800.0,gbp-million
+K02000001,quarter/2019-Q2,FGZA,12,exports,gbp-total,784.0,gbp-million
+K02000001,quarter/2019-Q3,FGZA,12,exports,gbp-total,810.0,gbp-million
+K02000001,quarter/2019-Q4,FGZA,12,exports,gbp-total,843.0,gbp-million
+K02000001,quarter/2020-Q1,FGZA,12,exports,gbp-total,809.0,gbp-million
+K02000001,year/2018,IKBB,0,exports,gbp-total,306870.0,gbp-million
+K02000001,year/2019,IKBB,0,exports,gbp-total,327842.0,gbp-million
+K02000001,quarter/2018-Q2,IKBB,0,exports,gbp-total,75079.0,gbp-million
+K02000001,quarter/2018-Q3,IKBB,0,exports,gbp-total,77267.0,gbp-million
+K02000001,quarter/2018-Q4,IKBB,0,exports,gbp-total,80101.0,gbp-million
+K02000001,quarter/2019-Q1,IKBB,0,exports,gbp-total,79408.0,gbp-million
+K02000001,quarter/2019-Q2,IKBB,0,exports,gbp-total,80657.0,gbp-million
+K02000001,quarter/2019-Q3,IKBB,0,exports,gbp-total,83739.0,gbp-million
+K02000001,quarter/2019-Q4,IKBB,0,exports,gbp-total,84038.0,gbp-million
+K02000001,quarter/2020-Q1,IKBB,0,exports,gbp-total,77277.0,gbp-million
+K02000001,year/2018,MTN6,1+2,imports,gbp-total,2151.0,gbp-million
+K02000001,year/2019,MTN6,1+2,imports,gbp-total,2819.0,gbp-million
+K02000001,quarter/2018-Q2,MTN6,1+2,imports,gbp-total,442.0,gbp-million
+K02000001,quarter/2018-Q3,MTN6,1+2,imports,gbp-total,448.0,gbp-million
+K02000001,quarter/2018-Q4,MTN6,1+2,imports,gbp-total,725.0,gbp-million
+K02000001,quarter/2019-Q1,MTN6,1+2,imports,gbp-total,689.0,gbp-million
+K02000001,quarter/2019-Q2,MTN6,1+2,imports,gbp-total,692.0,gbp-million
+K02000001,quarter/2019-Q3,MTN6,1+2,imports,gbp-total,719.0,gbp-million
+K02000001,quarter/2019-Q4,MTN6,1+2,imports,gbp-total,719.0,gbp-million
+K02000001,quarter/2020-Q1,MTN6,1+2,imports,gbp-total,550.0,gbp-million
+K02000001,year/2018,FHME,3,imports,gbp-total,25524.0,gbp-million
+K02000001,year/2019,FHME,3,imports,gbp-total,25639.0,gbp-million
+K02000001,quarter/2018-Q2,FHME,3,imports,gbp-total,6291.0,gbp-million
+K02000001,quarter/2018-Q3,FHME,3,imports,gbp-total,6471.0,gbp-million
+K02000001,quarter/2018-Q4,FHME,3,imports,gbp-total,6276.0,gbp-million
+K02000001,quarter/2019-Q1,FHME,3,imports,gbp-total,6389.0,gbp-million
+K02000001,quarter/2019-Q2,FHME,3,imports,gbp-total,6426.0,gbp-million
+K02000001,quarter/2019-Q3,FHME,3,imports,gbp-total,6469.0,gbp-million
+K02000001,quarter/2019-Q4,FHME,3,imports,gbp-total,6355.0,gbp-million
+K02000001,quarter/2020-Q1,FHME,3,imports,gbp-total,6075.0,gbp-million
+K02000001,year/2018,APQL,4,imports,gbp-total,51742.0,gbp-million
+K02000001,year/2019,APQL,4,imports,gbp-total,55619.0,gbp-million
+K02000001,quarter/2018-Q2,APQL,4,imports,gbp-total,12671.0,gbp-million
+K02000001,quarter/2018-Q3,APQL,4,imports,gbp-total,13063.0,gbp-million
+K02000001,quarter/2018-Q4,APQL,4,imports,gbp-total,13112.0,gbp-million
+K02000001,quarter/2019-Q1,APQL,4,imports,gbp-total,13103.0,gbp-million
+K02000001,quarter/2019-Q2,APQL,4,imports,gbp-total,13567.0,gbp-million
+K02000001,quarter/2019-Q3,APQL,4,imports,gbp-total,14314.0,gbp-million
+K02000001,quarter/2019-Q4,APQL,4,imports,gbp-total,14635.0,gbp-million
+K02000001,quarter/2020-Q1,APQL,4,imports,gbp-total,10872.0,gbp-million
+K02000001,year/2018,FIOU,5,imports,gbp-total,2090.0,gbp-million
+K02000001,year/2019,FIOU,5,imports,gbp-total,2832.0,gbp-million
+K02000001,quarter/2018-Q2,FIOU,5,imports,gbp-total,465.0,gbp-million
+K02000001,quarter/2018-Q3,FIOU,5,imports,gbp-total,536.0,gbp-million
+K02000001,quarter/2018-Q4,FIOU,5,imports,gbp-total,590.0,gbp-million
+K02000001,quarter/2019-Q1,FIOU,5,imports,gbp-total,604.0,gbp-million
+K02000001,quarter/2019-Q2,FIOU,5,imports,gbp-total,593.0,gbp-million
+K02000001,quarter/2019-Q3,FIOU,5,imports,gbp-total,666.0,gbp-million
+K02000001,quarter/2019-Q4,FIOU,5,imports,gbp-total,969.0,gbp-million
+K02000001,quarter/2020-Q1,FIOU,5,imports,gbp-total,828.0,gbp-million
+K02000001,year/2018,FIPT,6,imports,gbp-total,3095.0,gbp-million
+K02000001,year/2019,FIPT,6,imports,gbp-total,3115.0,gbp-million
+K02000001,quarter/2018-Q2,FIPT,6,imports,gbp-total,734.0,gbp-million
+K02000001,quarter/2018-Q3,FIPT,6,imports,gbp-total,771.0,gbp-million
+K02000001,quarter/2018-Q4,FIPT,6,imports,gbp-total,857.0,gbp-million
+K02000001,quarter/2019-Q1,FIPT,6,imports,gbp-total,797.0,gbp-million
+K02000001,quarter/2019-Q2,FIPT,6,imports,gbp-total,739.0,gbp-million
+K02000001,quarter/2019-Q3,FIPT,6,imports,gbp-total,773.0,gbp-million
+K02000001,quarter/2019-Q4,FIPT,6,imports,gbp-total,806.0,gbp-million
+K02000001,quarter/2020-Q1,FIPT,6,imports,gbp-total,694.0,gbp-million
+K02000001,year/2018,FITY,7,imports,gbp-total,17017.0,gbp-million
+K02000001,year/2019,FITY,7,imports,gbp-total,19673.0,gbp-million
+K02000001,quarter/2018-Q2,FITY,7,imports,gbp-total,4057.0,gbp-million
+K02000001,quarter/2018-Q3,FITY,7,imports,gbp-total,4274.0,gbp-million
+K02000001,quarter/2018-Q4,FITY,7,imports,gbp-total,4805.0,gbp-million
+K02000001,quarter/2019-Q1,FITY,7,imports,gbp-total,4825.0,gbp-million
+K02000001,quarter/2019-Q2,FITY,7,imports,gbp-total,5022.0,gbp-million
+K02000001,quarter/2019-Q3,FITY,7,imports,gbp-total,5083.0,gbp-million
+K02000001,quarter/2019-Q4,FITY,7,imports,gbp-total,4743.0,gbp-million
+K02000001,quarter/2020-Q1,FITY,7,imports,gbp-total,4710.0,gbp-million
+K02000001,year/2018,FIVX,8,imports,gbp-total,10860.0,gbp-million
+K02000001,year/2019,FIVX,8,imports,gbp-total,13269.0,gbp-million
+K02000001,quarter/2018-Q2,FIVX,8,imports,gbp-total,2630.0,gbp-million
+K02000001,quarter/2018-Q3,FIVX,8,imports,gbp-total,2708.0,gbp-million
+K02000001,quarter/2018-Q4,FIVX,8,imports,gbp-total,2928.0,gbp-million
+K02000001,quarter/2019-Q1,FIVX,8,imports,gbp-total,3132.0,gbp-million
+K02000001,quarter/2019-Q2,FIVX,8,imports,gbp-total,3343.0,gbp-million
+K02000001,quarter/2019-Q3,FIVX,8,imports,gbp-total,3427.0,gbp-million
+K02000001,quarter/2019-Q4,FIVX,8,imports,gbp-total,3367.0,gbp-million
+K02000001,quarter/2020-Q1,FIVX,8,imports,gbp-total,2644.0,gbp-million
+K02000001,year/2018,FIUG,9,imports,gbp-total,10751.0,gbp-million
+K02000001,year/2019,FIUG,9,imports,gbp-total,10498.0,gbp-million
+K02000001,quarter/2018-Q2,FIUG,9,imports,gbp-total,2633.0,gbp-million
+K02000001,quarter/2018-Q3,FIUG,9,imports,gbp-total,2586.0,gbp-million
+K02000001,quarter/2018-Q4,FIUG,9,imports,gbp-total,2767.0,gbp-million
+K02000001,quarter/2019-Q1,FIUG,9,imports,gbp-total,2568.0,gbp-million
+K02000001,quarter/2019-Q2,FIUG,9,imports,gbp-total,2733.0,gbp-million
+K02000001,quarter/2019-Q3,FIUG,9,imports,gbp-total,2718.0,gbp-million
+K02000001,quarter/2019-Q4,FIUG,9,imports,gbp-total,2479.0,gbp-million
+K02000001,quarter/2020-Q1,FIUG,9,imports,gbp-total,2389.0,gbp-million
+K02000001,year/2018,FIWF,10,imports,gbp-total,66285.0,gbp-million
+K02000001,year/2019,FIWF,10,imports,gbp-total,80831.0,gbp-million
+K02000001,quarter/2018-Q2,FIWF,10,imports,gbp-total,16259.0,gbp-million
+K02000001,quarter/2018-Q3,FIWF,10,imports,gbp-total,16232.0,gbp-million
+K02000001,quarter/2018-Q4,FIWF,10,imports,gbp-total,18567.0,gbp-million
+K02000001,quarter/2019-Q1,FIWF,10,imports,gbp-total,17872.0,gbp-million
+K02000001,quarter/2019-Q2,FIWF,10,imports,gbp-total,18560.0,gbp-million
+K02000001,quarter/2019-Q3,FIWF,10,imports,gbp-total,20283.0,gbp-million
+K02000001,quarter/2019-Q4,FIWF,10,imports,gbp-total,24116.0,gbp-million
+K02000001,quarter/2020-Q1,FIWF,10,imports,gbp-total,18338.0,gbp-million
+K02000001,year/2018,FLQJ,11,imports,gbp-total,4095.0,gbp-million
+K02000001,year/2019,FLQJ,11,imports,gbp-total,4436.0,gbp-million
+K02000001,quarter/2018-Q2,FLQJ,11,imports,gbp-total,988.0,gbp-million
+K02000001,quarter/2018-Q3,FLQJ,11,imports,gbp-total,1098.0,gbp-million
+K02000001,quarter/2018-Q4,FLQJ,11,imports,gbp-total,1036.0,gbp-million
+K02000001,quarter/2019-Q1,FLQJ,11,imports,gbp-total,1041.0,gbp-million
+K02000001,quarter/2019-Q2,FLQJ,11,imports,gbp-total,1076.0,gbp-million
+K02000001,quarter/2019-Q3,FLQJ,11,imports,gbp-total,1175.0,gbp-million
+K02000001,quarter/2019-Q4,FLQJ,11,imports,gbp-total,1144.0,gbp-million
+K02000001,quarter/2020-Q1,FLQJ,11,imports,gbp-total,1169.0,gbp-million
+K02000001,year/2018,FLSA,12,imports,gbp-total,3682.0,gbp-million
+K02000001,year/2019,FLSA,12,imports,gbp-total,3641.0,gbp-million
+K02000001,quarter/2018-Q2,FLSA,12,imports,gbp-total,937.0,gbp-million
+K02000001,quarter/2018-Q3,FLSA,12,imports,gbp-total,857.0,gbp-million
+K02000001,quarter/2018-Q4,FLSA,12,imports,gbp-total,962.0,gbp-million
+K02000001,quarter/2019-Q1,FLSA,12,imports,gbp-total,921.0,gbp-million
+K02000001,quarter/2019-Q2,FLSA,12,imports,gbp-total,839.0,gbp-million
+K02000001,quarter/2019-Q3,FLSA,12,imports,gbp-total,958.0,gbp-million
+K02000001,quarter/2019-Q4,FLSA,12,imports,gbp-total,923.0,gbp-million
+K02000001,quarter/2020-Q1,FLSA,12,imports,gbp-total,894.0,gbp-million
+K02000001,year/2018,IKBC,0,imports,gbp-total,197292.0,gbp-million
+K02000001,year/2019,IKBC,0,imports,gbp-total,222372.0,gbp-million
+K02000001,quarter/2018-Q2,IKBC,0,imports,gbp-total,48107.0,gbp-million
+K02000001,quarter/2018-Q3,IKBC,0,imports,gbp-total,49044.0,gbp-million
+K02000001,quarter/2018-Q4,IKBC,0,imports,gbp-total,52625.0,gbp-million
+K02000001,quarter/2019-Q1,IKBC,0,imports,gbp-total,51941.0,gbp-million
+K02000001,quarter/2019-Q2,IKBC,0,imports,gbp-total,53590.0,gbp-million
+K02000001,quarter/2019-Q3,IKBC,0,imports,gbp-total,56585.0,gbp-million
+K02000001,quarter/2019-Q4,IKBC,0,imports,gbp-total,60256.0,gbp-million
+K02000001,quarter/2020-Q1,IKBC,0,imports,gbp-total,49163.0,gbp-million
+K02000001,year/2018,MTN8,1+2,balances,gbp-total,3540.0,gbp-million
+K02000001,year/2019,MTN8,1+2,balances,gbp-total,3615.0,gbp-million
+K02000001,quarter/2018-Q2,MTN8,1+2,balances,gbp-total,930.0,gbp-million
+K02000001,quarter/2018-Q3,MTN8,1+2,balances,gbp-total,1019.0,gbp-million
+K02000001,quarter/2018-Q4,MTN8,1+2,balances,gbp-total,758.0,gbp-million
+K02000001,quarter/2019-Q1,MTN8,1+2,balances,gbp-total,913.0,gbp-million
+K02000001,quarter/2019-Q2,MTN8,1+2,balances,gbp-total,924.0,gbp-million
+K02000001,quarter/2019-Q3,MTN8,1+2,balances,gbp-total,903.0,gbp-million
+K02000001,quarter/2019-Q4,MTN8,1+2,balances,gbp-total,875.0,gbp-million
+K02000001,quarter/2020-Q1,MTN8,1+2,balances,gbp-total,928.0,gbp-million
+K02000001,year/2018,FLYS,3,balances,gbp-total,3945.0,gbp-million
+K02000001,year/2019,FLYS,3,balances,gbp-total,5610.0,gbp-million
+K02000001,quarter/2018-Q2,FLYS,3,balances,gbp-total,870.0,gbp-million
+K02000001,quarter/2018-Q3,FLYS,3,balances,gbp-total,895.0,gbp-million
+K02000001,quarter/2018-Q4,FLYS,3,balances,gbp-total,1229.0,gbp-million
+K02000001,quarter/2019-Q1,FLYS,3,balances,gbp-total,1479.0,gbp-million
+K02000001,quarter/2019-Q2,FLYS,3,balances,gbp-total,1375.0,gbp-million
+K02000001,quarter/2019-Q3,FLYS,3,balances,gbp-total,1076.0,gbp-million
+K02000001,quarter/2019-Q4,FLYS,3,balances,gbp-total,1680.0,gbp-million
+K02000001,quarter/2020-Q1,FLYS,3,balances,gbp-total,1058.0,gbp-million
+K02000001,year/2018,FNGY,4,balances,gbp-total,-15311.0,gbp-million
+K02000001,year/2019,FNGY,4,balances,gbp-total,-16104.0,gbp-million
+K02000001,quarter/2018-Q2,FNGY,4,balances,gbp-total,-3876.0,gbp-million
+K02000001,quarter/2018-Q3,FNGY,4,balances,gbp-total,-4386.0,gbp-million
+K02000001,quarter/2018-Q4,FNGY,4,balances,gbp-total,-4102.0,gbp-million
+K02000001,quarter/2019-Q1,FNGY,4,balances,gbp-total,-4101.0,gbp-million
+K02000001,quarter/2019-Q2,FNGY,4,balances,gbp-total,-4149.0,gbp-million
+K02000001,quarter/2019-Q3,FNGY,4,balances,gbp-total,-3979.0,gbp-million
+K02000001,quarter/2019-Q4,FNGY,4,balances,gbp-total,-3875.0,gbp-million
+K02000001,quarter/2020-Q1,FNGY,4,balances,gbp-total,-4495.0,gbp-million
+K02000001,year/2018,FNJM,5,balances,gbp-total,581.0,gbp-million
+K02000001,year/2019,FNJM,5,balances,gbp-total,88.0,gbp-million
+K02000001,quarter/2018-Q2,FNJM,5,balances,gbp-total,127.0,gbp-million
+K02000001,quarter/2018-Q3,FNJM,5,balances,gbp-total,123.0,gbp-million
+K02000001,quarter/2018-Q4,FNJM,5,balances,gbp-total,137.0,gbp-million
+K02000001,quarter/2019-Q1,FNJM,5,balances,gbp-total,77.0,gbp-million
+K02000001,quarter/2019-Q2,FNJM,5,balances,gbp-total,173.0,gbp-million
+K02000001,quarter/2019-Q3,FNJM,5,balances,gbp-total,63.0,gbp-million
+K02000001,quarter/2019-Q4,FNJM,5,balances,gbp-total,-225.0,gbp-million
+K02000001,quarter/2020-Q1,FNJM,5,balances,gbp-total,-129.0,gbp-million
+K02000001,year/2018,FNKF,6,balances,gbp-total,16330.0,gbp-million
+K02000001,year/2019,FNKF,6,balances,gbp-total,17038.0,gbp-million
+K02000001,quarter/2018-Q2,FNKF,6,balances,gbp-total,3997.0,gbp-million
+K02000001,quarter/2018-Q3,FNKF,6,balances,gbp-total,4302.0,gbp-million
+K02000001,quarter/2018-Q4,FNKF,6,balances,gbp-total,4028.0,gbp-million
+K02000001,quarter/2019-Q1,FNKF,6,balances,gbp-total,4160.0,gbp-million
+K02000001,quarter/2019-Q2,FNKF,6,balances,gbp-total,4277.0,gbp-million
+K02000001,quarter/2019-Q3,FNKF,6,balances,gbp-total,4270.0,gbp-million
+K02000001,quarter/2019-Q4,FNKF,6,balances,gbp-total,4331.0,gbp-million
+K02000001,quarter/2020-Q1,FNKF,6,balances,gbp-total,4414.0,gbp-million
+K02000001,year/2018,FNLQ,7,balances,gbp-total,46205.0,gbp-million
+K02000001,year/2019,FNLQ,7,balances,gbp-total,43624.0,gbp-million
+K02000001,quarter/2018-Q2,FNLQ,7,balances,gbp-total,12184.0,gbp-million
+K02000001,quarter/2018-Q3,FNLQ,7,balances,gbp-total,11398.0,gbp-million
+K02000001,quarter/2018-Q4,FNLQ,7,balances,gbp-total,11049.0,gbp-million
+K02000001,quarter/2019-Q1,FNLQ,7,balances,gbp-total,10993.0,gbp-million
+K02000001,quarter/2019-Q2,FNLQ,7,balances,gbp-total,9927.0,gbp-million
+K02000001,quarter/2019-Q3,FNLQ,7,balances,gbp-total,11423.0,gbp-million
+K02000001,quarter/2019-Q4,FNLQ,7,balances,gbp-total,11281.0,gbp-million
+K02000001,quarter/2020-Q1,FNLQ,7,balances,gbp-total,11879.0,gbp-million
+K02000001,year/2018,FNMR,8,balances,gbp-total,8861.0,gbp-million
+K02000001,year/2019,FNMR,8,balances,gbp-total,6507.0,gbp-million
+K02000001,quarter/2018-Q2,FNMR,8,balances,gbp-total,1986.0,gbp-million
+K02000001,quarter/2018-Q3,FNMR,8,balances,gbp-total,1857.0,gbp-million
+K02000001,quarter/2018-Q4,FNMR,8,balances,gbp-total,3203.0,gbp-million
+K02000001,quarter/2019-Q1,FNMR,8,balances,gbp-total,1476.0,gbp-million
+K02000001,quarter/2019-Q2,FNMR,8,balances,gbp-total,1699.0,gbp-million
+K02000001,quarter/2019-Q3,FNMR,8,balances,gbp-total,1360.0,gbp-million
+K02000001,quarter/2019-Q4,FNMR,8,balances,gbp-total,1972.0,gbp-million
+K02000001,quarter/2020-Q1,FNMR,8,balances,gbp-total,1503.0,gbp-million
+K02000001,year/2018,FNLY,9,balances,gbp-total,13209.0,gbp-million
+K02000001,year/2019,FNLY,9,balances,gbp-total,12902.0,gbp-million
+K02000001,quarter/2018-Q2,FNLY,9,balances,gbp-total,3151.0,gbp-million
+K02000001,quarter/2018-Q3,FNLY,9,balances,gbp-total,3430.0,gbp-million
+K02000001,quarter/2018-Q4,FNLY,9,balances,gbp-total,3482.0,gbp-million
+K02000001,quarter/2019-Q1,FNLY,9,balances,gbp-total,3095.0,gbp-million
+K02000001,quarter/2019-Q2,FNLY,9,balances,gbp-total,3024.0,gbp-million
+K02000001,quarter/2019-Q3,FNLY,9,balances,gbp-total,3286.0,gbp-million
+K02000001,quarter/2019-Q4,FNLY,9,balances,gbp-total,3497.0,gbp-million
+K02000001,quarter/2020-Q1,FNLY,9,balances,gbp-total,2937.0,gbp-million
+K02000001,year/2018,FNMZ,10,balances,gbp-total,32511.0,gbp-million
+K02000001,year/2019,FNMZ,10,balances,gbp-total,32218.0,gbp-million
+K02000001,quarter/2018-Q2,FNMZ,10,balances,gbp-total,7634.0,gbp-million
+K02000001,quarter/2018-Q3,FNMZ,10,balances,gbp-total,9610.0,gbp-million
+K02000001,quarter/2018-Q4,FNMZ,10,balances,gbp-total,7807.0,gbp-million
+K02000001,quarter/2019-Q1,FNMZ,10,balances,gbp-total,9351.0,gbp-million
+K02000001,quarter/2019-Q2,FNMZ,10,balances,gbp-total,9902.0,gbp-million
+K02000001,quarter/2019-Q3,FNMZ,10,balances,gbp-total,8852.0,gbp-million
+K02000001,quarter/2019-Q4,FNMZ,10,balances,gbp-total,4113.0,gbp-million
+K02000001,quarter/2020-Q1,FNMZ,10,balances,gbp-total,9908.0,gbp-million
+K02000001,year/2018,FNRB,11,balances,gbp-total,489.0,gbp-million
+K02000001,year/2019,FNRB,11,balances,gbp-total,376.0,gbp-million
+K02000001,quarter/2018-Q2,FNRB,11,balances,gbp-total,173.0,gbp-million
+K02000001,quarter/2018-Q3,FNRB,11,balances,gbp-total,77.0,gbp-million
+K02000001,quarter/2018-Q4,FNRB,11,balances,gbp-total,161.0,gbp-million
+K02000001,quarter/2019-Q1,FNRB,11,balances,gbp-total,145.0,gbp-million
+K02000001,quarter/2019-Q2,FNRB,11,balances,gbp-total,-30.0,gbp-million
+K02000001,quarter/2019-Q3,FNRB,11,balances,gbp-total,48.0,gbp-million
+K02000001,quarter/2019-Q4,FNRB,11,balances,gbp-total,213.0,gbp-million
+K02000001,quarter/2020-Q1,FNRB,11,balances,gbp-total,196.0,gbp-million
+K02000001,year/2018,FNRU,12,balances,gbp-total,-782.0,gbp-million
+K02000001,year/2019,FNRU,12,balances,gbp-total,-404.0,gbp-million
+K02000001,quarter/2018-Q2,FNRU,12,balances,gbp-total,-204.0,gbp-million
+K02000001,quarter/2018-Q3,FNRU,12,balances,gbp-total,-102.0,gbp-million
+K02000001,quarter/2018-Q4,FNRU,12,balances,gbp-total,-276.0,gbp-million
+K02000001,quarter/2019-Q1,FNRU,12,balances,gbp-total,-121.0,gbp-million
+K02000001,quarter/2019-Q2,FNRU,12,balances,gbp-total,-55.0,gbp-million
+K02000001,quarter/2019-Q3,FNRU,12,balances,gbp-total,-148.0,gbp-million
+K02000001,quarter/2019-Q4,FNRU,12,balances,gbp-total,-80.0,gbp-million
+K02000001,quarter/2020-Q1,FNRU,12,balances,gbp-total,-85.0,gbp-million
+K02000001,year/2018,IKBD,0,balances,gbp-total,109578.0,gbp-million
+K02000001,year/2019,IKBD,0,balances,gbp-total,105470.0,gbp-million
+K02000001,quarter/2018-Q2,IKBD,0,balances,gbp-total,26972.0,gbp-million
+K02000001,quarter/2018-Q3,IKBD,0,balances,gbp-total,28223.0,gbp-million
+K02000001,quarter/2018-Q4,IKBD,0,balances,gbp-total,27476.0,gbp-million
+K02000001,quarter/2019-Q1,IKBD,0,balances,gbp-total,27467.0,gbp-million
+K02000001,quarter/2019-Q2,IKBD,0,balances,gbp-total,27067.0,gbp-million
+K02000001,quarter/2019-Q3,IKBD,0,balances,gbp-total,27154.0,gbp-million
+K02000001,quarter/2019-Q4,IKBD,0,balances,gbp-total,23782.0,gbp-million
+K02000001,quarter/2020-Q1,IKBD,0,balances,gbp-total,28114.0,gbp-million

--- a/features/pmd.feature
+++ b/features/pmd.feature
@@ -51,7 +51,7 @@ Feature: PMD metadata
       And I scrape the page "https://www.ons.gov.uk/businessindustryandtrade/business/businessinnovation/datasets/foreigndirectinvestmentinvolvingukcompanies2013inwardtables"
       And generate TriG
       Then the dataset contents URI should be <http://gss-data.org.uk/data/gss_data/trade/ons-fdi-inward#dataset>
-      And the metadata graph should be <http://gss-data.org.uk/graph/gss_data/trade/ons-fdi-inward>
+      And the pmdcat:graph should be <http://gss-data.org.uk/graph/gss_data/trade/ons-fdi-inward>
       And the modified date should be quite recent
 
     Scenario: licensed dataset

--- a/features/steps/csvw.py
+++ b/features/steps/csvw.py
@@ -181,6 +181,11 @@ def step_impl(context, map_file):
     json.dump(mapping, context.json_io)
 
 
+@step("a containing graph URI '{uri}'")
+def step_impl(context, uri):
+    context.containing_graph_uri = uri
+
+
 @when("I create a CSVW file from the mapping and CSV")
 def step_impl(context):
     context.csvw = CSVWMapping()
@@ -190,6 +195,9 @@ def step_impl(context):
     context.csvw.set_mapping(json.load(context.json_io))
     context.json_io.seek(0)
     context.csvw.set_accretive_upload(json.load(context.json_io))
+
+    if "containing_graph_uri" in context and context.containing_graph_uri is not None:
+        context.csvw.set_containing_graph_uri(context.containing_graph_uri)
 
     if hasattr(context, 'registry'):
         context.csvw.set_registry(URI(context.registry))

--- a/features/steps/cubes.py
+++ b/features/steps/cubes.py
@@ -3,6 +3,10 @@ import json
 from behave import *
 from nose.tools import *
 from gssutils import *
+from io import BytesIO, SEEK_END, StringIO, TextIOBase
+
+
+from csvw import run_csv2rdf
 
 
 def get_fixture(file_name):
@@ -24,6 +28,27 @@ def step_impl(context, cube_name, csv_data, seed_name):
     context.cubes.add_cube(scraper, df, cube_name)
 
 
+@step('I add a cube "{cube_name}" with data "{csv_data}" and a scrape seed "{seed_name}" with override containing graph "{override_containing_graph}"')
+def step_impl(context, cube_name, csv_data, seed_name, override_containing_graph):
+    scraper = Scraper(seed=get_fixture(seed_name))
+    df = pd.read_csv(get_fixture(csv_data))
+    context.cubes.add_cube(scraper, df, cube_name, override_containing_graph=override_containing_graph)
+
+
 @step('the datacube outputs can be created')
 def step_impl(context):
     context.cubes.output_all()
+
+
+@step('generate RDF from the n={n} cube\'s CSV-W output')
+def step_impl(context, n):
+    n = int(n)
+    cube = context.cubes.cubes[n]
+
+    csv_file_path = Path("out") / f'{pathify(cube.title)}.csv'
+    metadata_file_path = Path("out") / f'{pathify(cube.title)}.csv-metadata.json'
+
+    csv_io = open(csv_file_path, 'r', encoding='utf-8')
+    metadata_io = open(metadata_file_path, 'r', encoding='utf-8')
+    context.turtle = run_csv2rdf(csv_file_path, metadata_file_path, csv_io, metadata_io)
+

--- a/features/steps/rdf.py
+++ b/features/steps/rdf.py
@@ -108,9 +108,9 @@ def step_impl(context, uri):
     eq_(str(context.scraper.dataset.datasetContents.uri), uri)
 
 
-@step("the metadata graph should be <{uri}>")
+@step("the pmdcat:graph should be <{uri}>")
 def step_impl(context, uri):
-    eq_(str(context.scraper.dataset.graph), uri)
+    eq_(str(context.scraper.dataset.pmdcatGraph), uri)
 
 
 @step("the modified date should be quite recent")

--- a/gssutils/csvw/mapping.py
+++ b/gssutils/csvw/mapping.py
@@ -397,7 +397,13 @@ class CSVWMapping:
         )
         self._validate()
 
-        containing_graph_uri = self._containing_graph_uri or self.join_dataset_uri("#graph")
+        if self._containing_graph_uri is None:
+            print("WARNING: _containing_graph_uri is unset. Imputing graph URI from context.")
+            containing_graph_uri = self._dataset_uri.replace("gss-data.org.uk/data/gss_data",
+                                                             "gss-data.org.uk/graph/gss_data")
+        else:
+            containing_graph_uri = self._containing_graph_uri
+
         csvw_structure = {
             "@context": ["http://www.w3.org/ns/csvw", {"@language": "en"}],
             "tables": self._as_tables(),

--- a/gssutils/metadata/base.py
+++ b/gssutils/metadata/base.py
@@ -32,7 +32,7 @@ class Resource:
 
 class Metadata(Resource):
 
-    _core_properties = ['uri', '_uri', '_graph', '_seed']
+    _core_properties = ['uri', '_uri', '_containing_graph', '_seed']
     _properties_metadata = {
         'label': (RDFS.label, Status.mandatory, lambda s: Literal(s, 'en')),
         'comment': (RDFS.comment, Status.mandatory, lambda s: Literal(s, 'en'))
@@ -40,14 +40,20 @@ class Metadata(Resource):
 
     def __init__(self):
         super().__init__()
-        self._graph: Identifier = BNode()
+        self._containing_graph: Identifier = BNode()
         self._seed: Optional[dict] = None
 
-    def get_graph(self):
-        return str(self._graph)
+    def get_containing_graph(self):
+        """
+        The graph URI which this object's triples are to be stored in.
+        """
+        return str(self._containing_graph)
 
-    def set_graph(self, uri):
-        self._graph = URIRef(uri)
+    def set_containing_graph(self, uri):
+        """
+        The graph URI which this object's triples are to be stored in.
+        """
+        self._containing_graph = URIRef(uri)
 
     def __setattr__(self, name, value):
         if name in self._properties_metadata:
@@ -80,7 +86,7 @@ class Metadata(Resource):
         return (lambda x: x if type(x) == list else [x])(self.__dict__[local_name])
 
     def add_to_dataset(self, dataset):
-        graph = dataset.graph(self._graph)
+        graph = dataset.graph(self._containing_graph)
         for c in getmro(type(self)):
             if hasattr(c, '_type'):
                 if type(c._type) == tuple:

--- a/gssutils/metadata/dcat.py
+++ b/gssutils/metadata/dcat.py
@@ -53,9 +53,9 @@ class Dataset(Resource):
         if key == 'distribution':
             if type(value) == list:
                 for d in value:
-                    d._graph = self._graph
+                    d._containing_graph = self._containing_graph
             else:
-                value._graph = self._graph
+                value._containing_graph = self._containing_graph
         super().__setattr__(key, value)
 
 

--- a/gssutils/metadata/pmdcat.py
+++ b/gssutils/metadata/pmdcat.py
@@ -45,7 +45,8 @@ class Dataset(dcat.Dataset):
     _properties_metadata = dict(dcat.Dataset._properties_metadata)
     _properties_metadata.update({
         'metadataGraph': (PMDCAT.metadataGraph, Status.mandatory, URIRef),
-        'graph': (PMDCAT.graph, Status.mandatory, URIRef),
+        # pmdcat:graph declares the graph containing the qb:DataSet
+        'pmdcatGraph': (PMDCAT.graph, Status.mandatory, URIRef),
         'datasetContents': (PMDCAT.datasetContents, Status.mandatory, lambda d: URIRef(d.uri)),
         'markdownDescription': (PMDCAT.markdownDescription, Status.recommended, lambda l: Literal(l, MARKDOWN)),
         'sparqlEndpoint': (VOID.sparqlEndpoint, Status.mandatory, URIRef),
@@ -66,6 +67,4 @@ class Dataset(dcat.Dataset):
             # TODO: remove the following once we distinguish between the modification datetime of a dataset
             #       in PMD and the last modification datetime of the dataset by the publisher.
             value = datetime.now(timezone.utc).astimezone()
-        elif key == 'datasetContents':
-            value._graph = self._graph
         super().__setattr__(key, value)

--- a/gssutils/scrape.py
+++ b/gssutils/scrape.py
@@ -349,7 +349,7 @@ class Scraper:
 
     def update_dataset_uris(self):
         self.dataset.uri = urljoin(self._base_uri, f'data/{self._dataset_id}-catalog-entry')
-        self.dataset.set_graph(urljoin(self._base_uri, f'graph/{self._dataset_id}-metadata'))
+        self.dataset.set_graph(urljoin(self._base_uri, f'graph/{self._dataset_id}'))
 
     def set_family(self, family):
         self.dataset.family = family
@@ -380,7 +380,6 @@ class Scraper:
         if hasattr(catalog.record.primaryTopic, 'distribution'):
             for dist in ensure_list(catalog.record.primaryTopic.distribution):
                 dist.set_graph(metadata_graph)
-        self.dataset.graph = urljoin(self._base_uri, f'graph/{self._dataset_id}')
         self.dataset.datasetContents = pmdcat.DataCube()
         self.dataset.datasetContents.uri = urljoin(self._base_uri, f'data/{self._dataset_id}#dataset')
         self.dataset.sparqlEndpoint = urljoin(self._base_uri, '/sparql')

--- a/gssutils/scrape.py
+++ b/gssutils/scrape.py
@@ -349,7 +349,8 @@ class Scraper:
 
     def update_dataset_uris(self):
         self.dataset.uri = urljoin(self._base_uri, f'data/{self._dataset_id}-catalog-entry')
-        self.dataset.set_graph(urljoin(self._base_uri, f'graph/{self._dataset_id}'))
+        # Set the pmdcat:graph triple. It should point at the graph containing the qb:DataSet.
+        self.dataset.pmdcatGraph = urljoin(self._base_uri, f'graph/{self._dataset_id}')
 
     def set_family(self, family):
         self.dataset.family = family
@@ -367,10 +368,10 @@ class Scraper:
         else:
             catalog.uri = urljoin(self._base_uri, 'catalog/datasets')
         metadata_graph = urljoin(self._base_uri, f'graph/{self._dataset_id}-metadata')
-        catalog.set_graph(metadata_graph)
+        catalog.set_containing_graph(metadata_graph)
         catalog.record = pmdcat.CatalogRecord()
         catalog.record.uri = urljoin(self._base_uri, f'data/{self._dataset_id}-catalog-record')
-        catalog.record.set_graph(metadata_graph)
+        catalog.record.set_containing_graph(metadata_graph)
         catalog.record.label = self.dataset.label + " Catalog Record"
         catalog.record.metadataGraph = metadata_graph
         catalog.record.issued = self.dataset.issued
@@ -379,7 +380,8 @@ class Scraper:
         # need to ensure that all the pointed to things are in the same graph
         if hasattr(catalog.record.primaryTopic, 'distribution'):
             for dist in ensure_list(catalog.record.primaryTopic.distribution):
-                dist.set_graph(metadata_graph)
+                dist.set_containing_graph(metadata_graph)
+        self.dataset.set_containing_graph(metadata_graph)
         self.dataset.datasetContents = pmdcat.DataCube()
         self.dataset.datasetContents.uri = urljoin(self._base_uri, f'data/{self._dataset_id}#dataset')
         self.dataset.sparqlEndpoint = urljoin(self._base_uri, '/sparql')

--- a/gssutils/transform/cubes.py
+++ b/gssutils/transform/cubes.py
@@ -107,6 +107,7 @@ class Cube:
 
         map_obj.set_csv(destination_folder / f'{pathified_title}.csv')
         map_obj.set_dataset_uri(urljoin(self.scraper._base_uri, f'data/{self.scraper._dataset_id}'))
+        map_obj.set_containing_graph_uri(self.scraper.dataset.graph)
 
         return map_obj
 

--- a/gssutils/transform/cubes.py
+++ b/gssutils/transform/cubes.py
@@ -107,7 +107,7 @@ class Cube:
 
         map_obj.set_csv(destination_folder / f'{pathified_title}.csv')
         map_obj.set_dataset_uri(urljoin(self.scraper._base_uri, f'data/{self.scraper._dataset_id}'))
-        map_obj.set_containing_graph_uri(self.scraper.dataset.graph)
+        map_obj.set_containing_graph_uri(self.scraper.dataset.pmdcatGraph)
 
         return map_obj
 

--- a/gssutils/transform/cubes.py
+++ b/gssutils/transform/cubes.py
@@ -87,7 +87,7 @@ class Cube:
     override_containing_graph_uri: Optional[str]
 
     def __init__(self, base_uri, scraper, dataframe, title, graph, info_json_dict,
-                 override_containing_graph_uri: Optional[str] = None):
+                 override_containing_graph_uri: Optional[str]):
 
         self.scraper = scraper  # note - the metadata of a scrape, not the actual data source
         self.dataframe = dataframe


### PR DESCRIPTION
https://github.com/GSS-Cogs/pmd-jenkins-library/issues/66

Jenkins will be altered to pull the Graph URI from the explicit `sd:NamedGraph` node instead of simply using the #dataset URI.