### PR TITLE
Fix wrong graph error in trig file

### DIFF
--- a/gssutils/scrape.py
+++ b/gssutils/scrape.py
@@ -383,6 +383,7 @@ class Scraper:
                 dist.set_containing_graph(metadata_graph)
         self.dataset.set_containing_graph(metadata_graph)
         self.dataset.datasetContents = pmdcat.DataCube()
+        self.dataset.datasetContents.set_containing_graph(metadata_graph)
         self.dataset.datasetContents.uri = urljoin(self._base_uri, f'data/{self._dataset_id}#dataset')
         self.dataset.sparqlEndpoint = urljoin(self._base_uri, '/sparql')
         quads = RDFDataset()


### PR DESCRIPTION
When deploying updates to gss-utils yesterday, it transpired that we were incorrectly specifying two metadata graphs in the `.trig` file. This caused uploads to PMD to fail since the graph that we found first was an empty node (so we weren't giving PMD a graph to insert the data into):

```
[] {
  <http://gss-data.org.uk/data/gss_data/trade/hmrc-alcohol-bulletin/alcohol-bulletin-clearances#dataset>
    a pmdcat:DataCube .
}

ns1:alcohol-bulletin-clearances-metadata {
  <http://gss-data.org.uk/catalog/datasets> a dcat:Catalog;
    dcat:record <http://gss-data.org.uk/data/gss_data/trade/hmrc-alcohol-bulletin/alcohol-bulletin-clearances-catalog-record> .
  
...
```

Unfortunately, there is no easy way to be able to test this since `rdflib` doesn't support parsing quads files (i.e. triples with graph specified) properly. I did write a test for this, but it simply doesn't work - but I have verified that this fix actually fixes the problem experiences when generating trig files.

https://github.com/GSS-Cogs/pmd-jenkins-library/issues/66