### PR TITLE
Issue #247 - Suppress catalog and DSD metadata independently of accretive upload functionality

### DIFF
--- a/features/csvw.feature
+++ b/features/csvw.feature
@@ -389,7 +389,7 @@ Scenario: Ensure column definition `value` field is respected when `parent` is n
           .
     """
 
- Scenario: Do not output Data Structure Definition or Trig when performing an accretive upload
+ Scenario: Do not output Data Structure Definition when performing an accretive upload
     Given a CSV file 'product-observations.csv'
     And a JSON map file 'mapping-info-accretive-test.json'
     And a dataset URI 'http://gss-data.org.uk/data/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity'
@@ -399,6 +399,16 @@ Scenario: Ensure column definition `value` field is respected when `parent` is n
     And the RDF should pass the Data Cube integrity constraints
     And the ask query 'dsd-components-exist.sparql' should return False
 
+ Scenario: Do not output Data Structure Definition when output suppressed
+    Given a CSV file 'product-observations.csv'
+    And a JSON map file 'mapping-info.json'
+    And a dataset URI 'http://gss-data.org.uk/data/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity'
+    And and the catalog and DSD metadata output should be suppressed
+    When I create a CSVW file from the mapping and CSV
+    Then the metadata is valid JSON-LD
+    And gsscogs/csv2rdf generates RDF
+    And the RDF should pass the Data Cube integrity constraints
+    And the ask query 'dsd-components-exist.sparql' should return False
 
 Scenario: A user wishes to specify a parent dimension for a locally defined dataset dimension
     Given a CSV file 'life-expectancy.csv'

--- a/features/cubes.feature
+++ b/features/cubes.feature
@@ -51,3 +51,16 @@ Feature: Creating cubes
 
     <http://containing-graph-uri> a sd:NamedGraph.
     """
+
+    Scenario: Suppressing catalog and DSD output should ensure trig file not generated
+    Given I want to create datacubes from the seed "seed-temp-scrape-quarterly-balance-of-payments.json"
+    And I specify a datacube named "trig file output test cube 1" with data "quarterly-balance-of-payments.csv" and a scrape using the seed "seed-temp-scrape-quarterly-balance-of-payments.json"
+    Then the datacube outputs can be created
+    And the file at "out/trig-file-output-test-cube-1.csv-metadata.trig" should exist
+
+    Scenario: Suppressing catalog and DSD output should ensure trig file not generated
+    Given I want to create datacubes from the seed "seed-temp-scrape-quarterly-balance-of-payments.json"
+    And and the catalog and DSD metadata output should be suppressed
+    And I specify a datacube named "trig file output test cube 2" with data "quarterly-balance-of-payments.csv" and a scrape using the seed "seed-temp-scrape-quarterly-balance-of-payments.json"
+    Then the datacube outputs can be created
+    And the file at "out/trig-file-output-test-cube-2.csv-metadata.trig" should not exist

--- a/features/steps/csvw.py
+++ b/features/steps/csvw.py
@@ -199,6 +199,9 @@ def step_impl(context):
     if "containing_graph_uri" in context and context.containing_graph_uri is not None:
         context.csvw.set_containing_graph_uri(context.containing_graph_uri)
 
+    if "suppress_catalog_dsd_output" in context:
+        context.csvw.set_suppress_catalog_and_dsd_output(context.suppress_catalog_dsd_output)
+
     if hasattr(context, 'registry'):
         context.csvw.set_registry(URI(context.registry))
     if hasattr(context, 'dataset_uri'):
@@ -216,6 +219,11 @@ def step_impl(context, endpoint):
 @step("a dataset URI '{uri}'")
 def step_impl(context, uri):
     context.dataset_uri = uri
+
+
+@step("and the catalog and DSD metadata output should be suppressed")
+def step_impl(context):
+    context.suppress_catalog_dsd_output = True
 
 
 @step("the RDF should pass the PMD4 constraints")

--- a/features/steps/cubes.py
+++ b/features/steps/cubes.py
@@ -25,14 +25,17 @@ def step_impl(context, seed_name):
 def step_impl(context, cube_name, csv_data, seed_name):
     scraper = Scraper(seed=get_fixture(seed_name))
     df = pd.read_csv(get_fixture(csv_data))
-    context.cubes.add_cube(scraper, df, cube_name)
+    suppress_catalog_dsd_output = context.suppress_catalog_dsd_output if "suppress_catalog_dsd_output" in context else False
+    context.cubes.add_cube(scraper, df, cube_name, suppress_catalog_and_dsd_output=suppress_catalog_dsd_output)
 
 
 @step('I add a cube "{cube_name}" with data "{csv_data}" and a scrape seed "{seed_name}" with override containing graph "{override_containing_graph}"')
 def step_impl(context, cube_name, csv_data, seed_name, override_containing_graph):
     scraper = Scraper(seed=get_fixture(seed_name))
     df = pd.read_csv(get_fixture(csv_data))
-    context.cubes.add_cube(scraper, df, cube_name, override_containing_graph=override_containing_graph)
+    suppress_catalog_dsd_output = context.suppress_catalog_dsd_output if "suppress_catalog_dsd_output" in context else False
+    context.cubes.add_cube(scraper, df, cube_name, override_containing_graph=override_containing_graph,
+                           suppress_catalog_and_dsd_output=suppress_catalog_dsd_output)
 
 
 @step('the datacube outputs can be created')

--- a/features/steps/rdf.py
+++ b/features/steps/rdf.py
@@ -59,6 +59,16 @@ def step_impl(context, trig_file):
     )
 
 
+@then('the file at "{file}" should not exist')
+def step_impl(context, file):
+    assert not Path(file).exists()
+
+
+@then('the file at "{file}" should exist')
+def step_impl(context, file):
+    assert Path(file).exists()
+
+
 @step("the RDF should contain")
 def step_impl(context):
     test_graph_diff(

--- a/gssutils/csvw/mapping.py
+++ b/gssutils/csvw/mapping.py
@@ -45,6 +45,7 @@ class CSVWMapping:
         self._measureTypes: Optional[List[str]] = None
         self._accretive_upload: bool = False
         self._containing_graph_uri: Optional[URI] = None
+        self._suppress_catalog_and_dsd_output: bool = False
 
     @staticmethod
     def namify(column_header: str):
@@ -106,6 +107,9 @@ class CSVWMapping:
             self._mapping = mapping['transform']['columns']
         else:
             logging.error(f'No column mapping found.')
+
+    def set_suppress_catalog_and_dsd_output(self, should_suppress: bool):
+        self._suppress_catalog_and_dsd_output = should_suppress
 
     def set_additional_foreign_key(self, foreign_key: ForeignKey):
         if self._foreign_keys is None:
@@ -417,7 +421,7 @@ class CSVWMapping:
             }
         }
 
-        if not self._accretive_upload:
+        if not self._accretive_upload and not self._suppress_catalog_and_dsd_output:
             # Don't want to upload DSD twice where we're just adding new data to existing data.
             # void:rootResource => https://www.w3.org/TR/void/#root-resource
             csvw_structure["void:rootResource"] = DataSet(

--- a/gssutils/transform/cubes.py
+++ b/gssutils/transform/cubes.py
@@ -36,12 +36,13 @@ class Cubes:
             logging.warning("The passing of job_name= has been depreciated and no longer does anything, please"
                             "remove this keyword argument")
 
-    def add_cube(self, scraper, dataframe, title, graph=None, info_json_dict=None, override_containing_graph=None):
+    def add_cube(self, scraper, dataframe, title, graph=None, info_json_dict=None, override_containing_graph=None,
+                 suppress_catalog_and_dsd_output: bool = False):
         """
         Add a single datacube to the cubes class.
         """
         self.cubes.append(Cube(self.base_uri, scraper, dataframe, title, graph, info_json_dict,
-                               override_containing_graph))
+                               override_containing_graph, suppress_catalog_and_dsd_output))
 
     def output_all(self):
         """
@@ -87,7 +88,7 @@ class Cube:
     override_containing_graph_uri: Optional[str]
 
     def __init__(self, base_uri, scraper, dataframe, title, graph, info_json_dict,
-                 override_containing_graph_uri: Optional[str]):
+                 override_containing_graph_uri: Optional[str], suppress_catalog_and_dsd_output: bool):
 
         self.scraper = scraper  # note - the metadata of a scrape, not the actual data source
         self.dataframe = dataframe
@@ -96,6 +97,7 @@ class Cube:
         self.graph = graph
         self.info_json_dict = copy.deepcopy(info_json_dict)  # don't copy a pointer, snapshot a thing
         self.override_containing_graph_uri = override_containing_graph_uri
+        self.suppress_catalog_and_dsd_output = suppress_catalog_and_dsd_output
 
     def _instantiate_map(self, destination_folder, pathified_title, info_json):
         """
@@ -109,6 +111,7 @@ class Cube:
 
         map_obj.set_accretive_upload(info_json)
         map_obj.set_mapping(info_json)
+        map_obj.set_suppress_catalog_and_dsd_output(self.suppress_catalog_and_dsd_output)
 
         map_obj.set_csv(destination_folder / f'{pathified_title}.csv')
         map_obj.set_dataset_uri(urljoin(self.scraper._base_uri, f'data/{self.scraper._dataset_id}'))
@@ -167,9 +170,9 @@ class Cube:
         is_accretive_upload = info_json is not None and "load" in info_json and "accretiveUpload" in info_json["load"] \
                               and info_json["load"]["accretiveUpload"]
 
-        # Don't output trig file if we're performing an accretive upload.
+        # Don't output trig file if we're performing an accretive upload (or we have been asked to suppress it).
         # We don't want to duplicate information we already have.
-        if not is_accretive_upload:
+        if not is_accretive_upload and not self.suppress_catalog_and_dsd_output:
             # Output the trig
             trig_to_use = self.scraper.generate_trig()
             with open(destination_folder / f'{pathify(self.title)}.csv-metadata.trig', 'wb') as metadata:


### PR DESCRIPTION
In order to add support for multi-graph datasets without having to use the accretive upload functionality, we need to be able to suppress the catalog metadata and DSD metadata from being output on a cube-by-cube basis.

The primary graph (file) should contain the DSD and have a complementary `.trig` file. The secondary graph files should not have either of these things (to avoid duplication).

This PR allows us to suppress these bits of metadata on a cube-by-cube basis. The decision on which cube contains the DSD and has the associated catalogue metadata will be decided in each transformation's main.py file.