### PR TITLE
codelist-manager- Stop URL templates being escaped by CSV2RDF

### DIFF
--- a/features/codelist-manager.feature
+++ b/features/codelist-manager.feature
@@ -415,7 +415,7 @@ Scenario: Correct the "@id" when it's "#table" and we have skos:inScheme defined
       }
       """
 
-Scenario: Escape the notation URIS column templates where they haven't been escaped.
+Scenario: Correct escaped notation/parent_notation column URL templates.
     Given We have a metadata file of the form
       """
       {

--- a/features/codelist-manager.feature
+++ b/features/codelist-manager.feature
@@ -152,7 +152,7 @@ Feature: Create and Manage CodeList Metadata files
                         },
                         "required": false,
                         "propertyUrl": "skos:broader",
-                        "valueUrl": "http://gss-data.org.uk/def/concept/my-favourite-code-list/{parent_notation}"
+                        "valueUrl": "http://gss-data.org.uk/def/concept/my-favourite-code-list/{+parent_notation}"
                     },
                     {
                         "titles": "Sort Priority",
@@ -180,7 +180,7 @@ Feature: Create and Manage CodeList Metadata files
                     }
                 ],
                 "primaryKey": "notation",
-                "aboutUrl": "http://gss-data.org.uk/def/concept/my-favourite-code-list/{notation}"
+                "aboutUrl": "http://gss-data.org.uk/def/concept/my-favourite-code-list/{+notation}"
             },
             "prov:hadDerivation": {
                 "@id": "http://gss-data.org.uk/def/concept-scheme/my-favourite-code-list",
@@ -207,14 +207,14 @@ Feature: Create and Manage CodeList Metadata files
                 "columns": [
                     {
                         "propertyUrl": "skos:broader",
-                        "valueUrl": "http://gss-data.org.uk/def/my-favourite-family/concept/my-favourite-code-list/{parent_notation}"
+                        "valueUrl": "http://gss-data.org.uk/def/my-favourite-family/concept/my-favourite-code-list/{+parent_notation}"
                     },
                     {
                         "propertyUrl": "skos:inScheme",
                         "valueUrl": "http://gss-data.org.uk/def/my-favourite-family/concept-scheme/my-favourite-code-list"
                     }
                 ],
-                "aboutUrl": "http://gss-data.org.uk/def/my-favourite-family/concept/my-favourite-code-list/{notation}"
+                "aboutUrl": "http://gss-data.org.uk/def/my-favourite-family/concept/my-favourite-code-list/{+notation}"
             },
             "prov:hadDerivation": {
                 "@id": "http://gss-data.org.uk/def/my-favourite-family/concept-scheme/my-favourite-code-list"
@@ -245,14 +245,14 @@ Feature: Create and Manage CodeList Metadata files
                 "columns": [
                     {
                         "propertyUrl": "skos:broader",
-                        "valueUrl": "http://gss-data.org.uk/data/gss_data/my-favourite-family/almost-the-best-data-set#concept/my-favourite-code-list/{parent_notation}"
+                        "valueUrl": "http://gss-data.org.uk/data/gss_data/my-favourite-family/almost-the-best-data-set#concept/my-favourite-code-list/{+parent_notation}"
                     },
                     {
                         "propertyUrl": "skos:inScheme",
                         "valueUrl": "http://gss-data.org.uk/data/gss_data/my-favourite-family/almost-the-best-data-set#scheme/my-favourite-code-list"
                     }
                 ],
-                "aboutUrl": "http://gss-data.org.uk/data/gss_data/my-favourite-family/almost-the-best-data-set#concept/my-favourite-code-list/{notation}"
+                "aboutUrl": "http://gss-data.org.uk/data/gss_data/my-favourite-family/almost-the-best-data-set#concept/my-favourite-code-list/{+notation}"
             },
             "prov:hadDerivation": {
                 "@id": "http://gss-data.org.uk/data/gss_data/my-favourite-family/almost-the-best-data-set#scheme/my-favourite-code-list"
@@ -412,5 +412,49 @@ Scenario: Correct the "@id" when it's "#table" and we have skos:inScheme defined
       """
       {
         "@id": "http://gss-data.org.uk/def/concept-scheme/this-scheme-id"
+      }
+      """
+
+Scenario: Escape the notation URIS column templates where they haven't been escaped.
+    Given We have a metadata file of the form
+      """
+      {
+        "@context": "http://www.w3.org/ns/csvw",
+        "@id": "#table",
+        "url": "some-file.csv",
+        "tableSchema": {
+          "columns": [
+            {
+                "titles": "Notation",
+                "name": "notation",
+                "propertyUrl": "skos:notation"
+            },
+            {
+                "titles": "Parent Notation",
+                "name": "parent_notation",
+                "valueUrl": "http://gss-data.org.uk/def/concept-scheme/this-scheme-id/{parent_notation}"
+            }
+          ],
+          "aboutUrl": "http://gss-data.org.uk/def/concept-scheme/this-scheme-id/{notation}"
+        },
+        "prov:hadDerivation": {
+          "@type": "skos:ConceptScheme"
+        }
+      }
+      """
+    When We run an automatic upgrade on the metadata file
+    Then The following properties are set
+      """
+      {
+        "tableSchema": {
+          "columns": [
+            {
+                "titles": "Parent Notation",
+                "name": "parent_notation",
+                "valueUrl": "http://gss-data.org.uk/def/concept-scheme/this-scheme-id/{+parent_notation}"
+            }
+          ],
+          "aboutUrl": "http://gss-data.org.uk/def/concept-scheme/this-scheme-id/{+notation}"
+        }
       }
       """

--- a/gssutils/codelistmanager/applyupdates.py
+++ b/gssutils/codelistmanager/applyupdates.py
@@ -1,10 +1,12 @@
 from typing import Dict, List
 from datetime import datetime
 
+
 from .updates.dcat import ensure_dcat_metadata_populated
 from .updates.standardiselabels import standardise_labels
 from .updates.correctidiftable import correct_id_if_table
 from .config import pmdcat_base_uri
+from .updates.escape_uri_template_values import escape_uri_template_values
 
 
 def refactor_structure_with_updates(csvw_mapping: Dict, allow_human_input: bool):
@@ -55,3 +57,5 @@ def _refactor_table_mapping_with_updates(table_mapping: Dict, allow_human_input:
 
     ensure_dcat_metadata_populated(pmdcat_base_uri, allow_human_input, concept_scheme_uri,
                                    table_mapping, dt_now, catalog_label)
+
+    escape_uri_template_values(table_mapping)

--- a/gssutils/codelistmanager/createnew.py
+++ b/gssutils/codelistmanager/createnew.py
@@ -96,7 +96,7 @@ def generate_csvw_metadata(
     if "notation" in [c.lower() for c in column_names]:
         override(table_schema, {
             "primaryKey": "notation",
-            "aboutUrl": concept_base_uri + "/{notation}"
+            "aboutUrl": concept_base_uri + "/{+notation}"
         })
     else:
         print("WARNING: could not determine primary key. As a result, `aboutUrl` property is not specified and " +
@@ -163,7 +163,7 @@ def _generate_schema_for_column(column_name: str, concept_base_uri: str) -> Dict
             },
             "required": False,
             "propertyUrl": "skos:broader",
-            "valueUrl": concept_base_uri + "/{" + column_name_snake_case + "}"
+            "valueUrl": concept_base_uri + "/{+" + column_name_snake_case + "}"
         })
     elif column_name_lower == "sort priority":
         override(column, {

--- a/gssutils/codelistmanager/updates/escape_uri_template_values.py
+++ b/gssutils/codelistmanager/updates/escape_uri_template_values.py
@@ -1,0 +1,29 @@
+"""
+csv2rdf has been updated. It now means that URI templates are (correctly) being escaped.
+e.g. `https://some.uri/{notation}` will transform a `notation` value of 'stu/ff' to 'stu%2Fff'.
+
+Generally speaking, we don't want to URI encode values that we're placing in the `notation` column.
+So we need to alter out URI templates to the `{+col_name}` for, e.g. `https://some.uri/{+notation}`
+"""
+from typing import Dict, Any
+import re
+
+
+keys_of_interest = ["propertyUrl", "valueUrl", "aboutUrl"]
+
+
+def escape_uri_template_values(table_mapping: Dict):
+    def _escape_uri_template_values(key: str, value: Any) -> Any:
+        if isinstance(value, list):
+            return [_escape_uri_template_values(key, v) for v in value]
+        elif isinstance(value, dict):
+            for k, v in value.items():
+                value[k] = _escape_uri_template_values(k, v)
+            return value
+        elif key in keys_of_interest and isinstance(value, str):
+            return re.sub(r"\{([^+]+)\}", r"{+\1}", value)
+        else:
+            return value
+
+    _escape_uri_template_values("", table_mapping)
+


### PR DESCRIPTION
Issue #258 - Adding upgrade to codelist-manager so that it ensures that all codelist valueUrl/propertyUrl/aboutUrl properties do not escape the value found inside the notation/parent_nodation columns.