### PR TITLE
Remove rdflib 4.2.2 restriction

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -16,6 +16,14 @@
         ]
     },
     "default": {
+        "appnope": {
+            "hashes": [
+                "sha256:93aa393e9d6c54c5cd570ccadd8edad61ea0c4b9ea7a01409020c9aa019eb442",
+                "sha256:dd83cd4b5b460958838f6eb3000c660b1f9caf2a5b1de4264e941512f603258a"
+            ],
+            "markers": "sys_platform == 'darwin'",
+            "version": "==0.1.2"
+        },
         "argparse": {
             "hashes": [
                 "sha256:62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4",
@@ -52,10 +60,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.12.6"
-        },
-        "cerberus": {
-            "editable": true,
-            "path": "."
         },
         "certifi": {
             "hashes": [
@@ -145,18 +149,11 @@
         },
         "ipython": {
             "hashes": [
-                "sha256:0cff04bb042800129348701f7bd68a430a844e8fb193979c08f6c99f28bb735e",
-                "sha256:892743b65c21ed72b806a3a602cca408520b3200b89d1924f4b3d2cdb3692362"
+                "sha256:58b55ebfdfa260dad10d509702dc2857cb25ad82609506b070cf2d7b7df5af13",
+                "sha256:75b5e060a3417cf64f138e0bb78e58512742c57dc29db5a5058a2b1f0c10df02"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==7.26.0"
-        },
-        "ipython-genutils": {
-            "hashes": [
-                "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8",
-                "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"
-            ],
-            "version": "==0.2.0"
+            "version": "==7.27.0"
         },
         "isodate": {
             "hashes": [
@@ -533,15 +530,22 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
+        },
+        "pyrdfa3": {
+            "hashes": [
+                "sha256:157663a92b87df345b6f69bde235dff5f797891608e12fe1e4fa8dad687131ae",
+                "sha256:4da7ed49e8f524b573ed67e4f7bc7f403bff3be00546d7438fe263c924a91ccf"
+            ],
+            "version": "==3.5.3"
         },
         "python-dateutil": {
             "hashes": [
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.2"
         },
         "python-magic": {
@@ -596,10 +600,11 @@
         },
         "rdflib": {
             "hashes": [
-                "sha256:58d5994610105a457cff7fdfe3d683d87786c5028a45ae032982498a7e913d6f",
-                "sha256:da1df14552555c5c7715d8ce71c08f404c988c58a1ecd38552d0da4fc261280d"
+                "sha256:7ce4d757eb26f4dd43205ec340d8c097f29e5adfe45d6ea20238c731dc679879",
+                "sha256:bb24f0058070d5843503e15b37c597bc3858d328d11acd9476efad3aa62f555d"
             ],
-            "version": "==4.2.2"
+            "markers": "python_version >= '3.7'",
+            "version": "==6.0.0"
         },
         "rdflib-jsonld": {
             "hashes": [
@@ -623,23 +628,23 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "traitlets": {
             "hashes": [
-                "sha256:178f4ce988f69189f7e523337a3e11d91c786ded9360174a3d9ca83e79bc5396",
-                "sha256:69ff3f9d5351f31a7ad80443c2674b7099df13cc41fc5fa6e2f6d3b0330b0426"
+                "sha256:03f172516916220b58c9f19d7f854734136dd9528103d04e9bf139a92c9f54c4",
+                "sha256:bd382d7ea181fbbcce157c133db9a829ce06edffe097bcf3ab945b435452b46d"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==5.0.5"
+            "version": "==5.1.0"
         },
         "unidecode": {
             "hashes": [
-                "sha256:12435ef2fc4cdfd9cf1035a1db7e98b6b047fe591892e81f34e94959591fad00",
-                "sha256:8d73a97d387a956922344f6b74243c2c6771594659778744b2dbdaad8f6b727d"
+                "sha256:9f8235681cc520912fe02e7dd73d455c2f0471f39d36485bc278b97b3e2f2390",
+                "sha256:d01b0a22f7d90dea483da658782884de5162f40359fcaf79630738db93045c84"
             ],
-            "version": "==1.2.0"
+            "version": "==1.3.0"
         },
         "uritemplate": {
             "hashes": [
@@ -814,8 +819,10 @@
             "version": "==1.5.2"
         },
         "cerberus": {
-            "editable": true,
-            "path": "."
+            "hashes": [
+                "sha256:d1b21b3954b2498d9a79edf16b3170a3ac1021df88d197dc2ce5928ba519237c"
+            ],
+            "version": "==1.3.4"
         },
         "certifi": {
             "hashes": [
@@ -858,11 +865,11 @@
         },
         "docker": {
             "hashes": [
-                "sha256:3e8bc47534e0ca9331d72c32f2881bb13b93ded0bcdeab3c833fb7cf61c0a9a5",
-                "sha256:fc961d622160e8021c10d1bcabc388c57d55fb1f917175afbe24af442e6879bd"
+                "sha256:21ec4998e90dff7a7aaaa098ca8d839c7de412b89e6f6c30908372d58fecf663",
+                "sha256:9b17f0723d83c1f3418d2aa17bf90b24dbe97deda06208dd4262fa30a6ee87eb"
             ],
             "index": "pypi",
-            "version": "==5.0.0"
+            "version": "==5.0.2"
         },
         "idna": {
             "hashes": [
@@ -950,7 +957,7 @@
                 "sha256:089a471b06327103865dfec2dd844230c3c658a4a1b5b4c8b6c16c8f77577f9e",
                 "sha256:7f690b18d35048c15438d6d0571f9045cffbec5907e0b1ccf006f889e3a38c0b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.5.2"
         },
         "pathspec": {
@@ -1005,7 +1012,7 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
         },
         "python-dateutil": {
@@ -1013,7 +1020,7 @@
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.2"
         },
         "pyyaml": {
@@ -1053,49 +1060,49 @@
         },
         "regex": {
             "hashes": [
-                "sha256:03840a07a402576b8e3a6261f17eb88abd653ad4e18ec46ef10c9a63f8c99ebd",
-                "sha256:06ba444bbf7ede3890a912bd4904bb65bf0da8f0d8808b90545481362c978642",
-                "sha256:1f9974826aeeda32a76648fc677e3125ade379869a84aa964b683984a2dea9f1",
-                "sha256:330836ad89ff0be756b58758878409f591d4737b6a8cef26a162e2a4961c3321",
-                "sha256:38600fd58c2996829480de7d034fb2d3a0307110e44dae80b6b4f9b3d2eea529",
-                "sha256:3a195e26df1fbb40ebee75865f9b64ba692a5824ecb91c078cc665b01f7a9a36",
-                "sha256:41acdd6d64cd56f857e271009966c2ffcbd07ec9149ca91f71088574eaa4278a",
-                "sha256:45f97ade892ace20252e5ccecdd7515c7df5feeb42c3d2a8b8c55920c3551c30",
-                "sha256:4b0c211c55d4aac4309c3209833c803fada3fc21cdf7b74abedda42a0c9dc3ce",
-                "sha256:5d5209c3ba25864b1a57461526ebde31483db295fc6195fdfc4f8355e10f7376",
-                "sha256:615fb5a524cffc91ab4490b69e10ae76c1ccbfa3383ea2fad72e54a85c7d47dd",
-                "sha256:61e734c2bcb3742c3f454dfa930ea60ea08f56fd1a0eb52d8cb189a2f6be9586",
-                "sha256:640ccca4d0a6fcc6590f005ecd7b16c3d8f5d52174e4854f96b16f34c39d6cb7",
-                "sha256:6dbd51c3db300ce9d3171f4106da18fe49e7045232630fe3d4c6e37cb2b39ab9",
-                "sha256:71a904da8c9c02aee581f4452a5a988c3003207cb8033db426f29e5b2c0b7aea",
-                "sha256:8021dee64899f993f4b5cca323aae65aabc01a546ed44356a0965e29d7893c94",
-                "sha256:8b8d551f1bd60b3e1c59ff55b9e8d74607a5308f66e2916948cafd13480b44a3",
-                "sha256:93f9f720081d97acee38a411e861d4ce84cbc8ea5319bc1f8e38c972c47af49f",
-                "sha256:96f0c79a70642dfdf7e6a018ebcbea7ea5205e27d8e019cad442d2acfc9af267",
-                "sha256:9966337353e436e6ba652814b0a957a517feb492a98b8f9d3b6ba76d22301dcc",
-                "sha256:a34ba9e39f8269fd66ab4f7a802794ffea6d6ac500568ec05b327a862c21ce23",
-                "sha256:a49f85f0a099a5755d0a2cc6fc337e3cb945ad6390ec892332c691ab0a045882",
-                "sha256:a795829dc522227265d72b25d6ee6f6d41eb2105c15912c230097c8f5bfdbcdc",
-                "sha256:a89ca4105f8099de349d139d1090bad387fe2b208b717b288699ca26f179acbe",
-                "sha256:ac95101736239260189f426b1e361dc1b704513963357dc474beb0f39f5b7759",
-                "sha256:ae87ab669431f611c56e581679db33b9a467f87d7bf197ac384e71e4956b4456",
-                "sha256:b091dcfee169ad8de21b61eb2c3a75f9f0f859f851f64fdaf9320759a3244239",
-                "sha256:b511c6009d50d5c0dd0bab85ed25bc8ad6b6f5611de3a63a59786207e82824bb",
-                "sha256:b79dc2b2e313565416c1e62807c7c25c67a6ff0a0f8d83a318df464555b65948",
-                "sha256:bca14dfcfd9aae06d7d8d7e105539bd77d39d06caaae57a1ce945670bae744e0",
-                "sha256:c835c30f3af5c63a80917b72115e1defb83de99c73bc727bddd979a3b449e183",
-                "sha256:ccd721f1d4fc42b541b633d6e339018a08dd0290dc67269df79552843a06ca92",
-                "sha256:d6c2b1d78ceceb6741d703508cd0e9197b34f6bf6864dab30f940f8886e04ade",
-                "sha256:d6ec4ae13760ceda023b2e5ef1f9bc0b21e4b0830458db143794a117fdbdc044",
-                "sha256:d8b623fc429a38a881ab2d9a56ef30e8ea20c72a891c193f5ebbddc016e083ee",
-                "sha256:ea9753d64cba6f226947c318a923dadaf1e21cd8db02f71652405263daa1f033",
-                "sha256:ebbceefbffae118ab954d3cd6bf718f5790db66152f95202ebc231d58ad4e2c2",
-                "sha256:ecb6e7c45f9cd199c10ec35262b53b2247fb9a408803ed00ee5bb2b54aa626f5",
-                "sha256:ef9326c64349e2d718373415814e754183057ebc092261387a2c2f732d9172b2",
-                "sha256:f93a9d8804f4cec9da6c26c8cfae2c777028b4fdd9f49de0302e26e00bb86504",
-                "sha256:faf08b0341828f6a29b8f7dd94d5cf8cc7c39bfc3e67b78514c54b494b66915a"
+                "sha256:04f6b9749e335bb0d2f68c707f23bb1773c3fb6ecd10edf0f04df12a8920d468",
+                "sha256:08d74bfaa4c7731b8dac0a992c63673a2782758f7cfad34cf9c1b9184f911354",
+                "sha256:0fc1f8f06977c2d4f5e3d3f0d4a08089be783973fc6b6e278bde01f0544ff308",
+                "sha256:121f4b3185feaade3f85f70294aef3f777199e9b5c0c0245c774ae884b110a2d",
+                "sha256:1413b5022ed6ac0d504ba425ef02549a57d0f4276de58e3ab7e82437892704fc",
+                "sha256:1743345e30917e8c574f273f51679c294effba6ad372db1967852f12c76759d8",
+                "sha256:28fc475f560d8f67cc8767b94db4c9440210f6958495aeae70fac8faec631797",
+                "sha256:31a99a4796bf5aefc8351e98507b09e1b09115574f7c9dbb9cf2111f7220d2e2",
+                "sha256:328a1fad67445550b982caa2a2a850da5989fd6595e858f02d04636e7f8b0b13",
+                "sha256:473858730ef6d6ff7f7d5f19452184cd0caa062a20047f6d6f3e135a4648865d",
+                "sha256:4cde065ab33bcaab774d84096fae266d9301d1a2f5519d7bd58fc55274afbf7a",
+                "sha256:5f6a808044faae658f546dd5f525e921de9fa409de7a5570865467f03a626fc0",
+                "sha256:610b690b406653c84b7cb6091facb3033500ee81089867ee7d59e675f9ca2b73",
+                "sha256:66256b6391c057305e5ae9209941ef63c33a476b73772ca967d4a2df70520ec1",
+                "sha256:6eebf512aa90751d5ef6a7c2ac9d60113f32e86e5687326a50d7686e309f66ed",
+                "sha256:79aef6b5cd41feff359acaf98e040844613ff5298d0d19c455b3d9ae0bc8c35a",
+                "sha256:808ee5834e06f57978da3e003ad9d6292de69d2bf6263662a1a8ae30788e080b",
+                "sha256:8e44769068d33e0ea6ccdf4b84d80c5afffe5207aa4d1881a629cf0ef3ec398f",
+                "sha256:999ad08220467b6ad4bd3dd34e65329dd5d0df9b31e47106105e407954965256",
+                "sha256:9b006628fe43aa69259ec04ca258d88ed19b64791693df59c422b607b6ece8bb",
+                "sha256:9d05ad5367c90814099000442b2125535e9d77581855b9bee8780f1b41f2b1a2",
+                "sha256:a577a21de2ef8059b58f79ff76a4da81c45a75fe0bfb09bc8b7bb4293fa18983",
+                "sha256:a617593aeacc7a691cc4af4a4410031654f2909053bd8c8e7db837f179a630eb",
+                "sha256:abb48494d88e8a82601af905143e0de838c776c1241d92021e9256d5515b3645",
+                "sha256:ac88856a8cbccfc14f1b2d0b829af354cc1743cb375e7f04251ae73b2af6adf8",
+                "sha256:b4c220a1fe0d2c622493b0a1fd48f8f991998fb447d3cd368033a4b86cf1127a",
+                "sha256:b844fb09bd9936ed158ff9df0ab601e2045b316b17aa8b931857365ea8586906",
+                "sha256:bdc178caebd0f338d57ae445ef8e9b737ddf8fbc3ea187603f65aec5b041248f",
+                "sha256:c206587c83e795d417ed3adc8453a791f6d36b67c81416676cad053b4104152c",
+                "sha256:c61dcc1cf9fd165127a2853e2c31eb4fb961a4f26b394ac9fe5669c7a6592892",
+                "sha256:c7cb4c512d2d3b0870e00fbbac2f291d4b4bf2634d59a31176a87afe2777c6f0",
+                "sha256:d4a332404baa6665b54e5d283b4262f41f2103c255897084ec8f5487ce7b9e8e",
+                "sha256:d5111d4c843d80202e62b4fdbb4920db1dcee4f9366d6b03294f45ed7b18b42e",
+                "sha256:e1e8406b895aba6caa63d9fd1b6b1700d7e4825f78ccb1e5260551d168db38ed",
+                "sha256:e8690ed94481f219a7a967c118abaf71ccc440f69acd583cab721b90eeedb77c",
+                "sha256:ed283ab3a01d8b53de3a05bfdf4473ae24e43caee7dcb5584e86f3f3e5ab4374",
+                "sha256:ed4b50355b066796dacdd1cf538f2ce57275d001838f9b132fab80b75e8c84dd",
+                "sha256:ee329d0387b5b41a5dddbb6243a21cb7896587a651bebb957e2d2bb8b63c0791",
+                "sha256:f3bf1bc02bc421047bfec3343729c4bbbea42605bcfd6d6bfe2c07ade8b12d2a",
+                "sha256:f585cbbeecb35f35609edccb95efd95a3e35824cd7752b586503f7e6087303f1",
+                "sha256:f60667673ff9c249709160529ab39667d1ae9fd38634e006bec95611f632e759"
             ],
-            "version": "==2021.8.21"
+            "version": "==2021.8.28"
         },
         "requests": {
             "extras": [
@@ -1121,7 +1128,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "toml": {
@@ -1129,7 +1136,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
         },
         "tomli": {

--- a/features/steps/rdf.py
+++ b/features/steps/rdf.py
@@ -31,31 +31,49 @@ def step_impl(context):
 
 
 def test_graph_diff(g1, g2):
-    in_both, only_in_first, only_in_second = graph_diff(to_isomorphic(g1), to_isomorphic(g2))
+    in_both, only_in_first, only_in_second = graph_diff(
+        to_isomorphic(g1), to_isomorphic(g2)
+    )
     only_in_first.namespace_manager = g1.namespace_manager
     only_in_second.namespace_manager = g2.namespace_manager
-    ok_(len(only_in_second) == 0, f"""
+    only_in_first_n3 = only_in_first.serialize(format="n3")
+    only_in_first_n3 = (
+        only_in_first_n3
+        if isinstance(only_in_first_n3, str)
+        else only_in_first_n3.decode("utf-8")
+    )
+    only_in_second_n3 = only_in_second.serialize(format="n3")
+    only_in_second_n3 = (
+        only_in_second_n3
+        if isinstance(only_in_second_n3, str)
+        else only_in_second_n3.decode("utf-8")
+    )
+
+    ok_(
+        len(only_in_second) == 0,
+        f"""
 <<<
-{only_in_first.serialize(format='n3').decode('utf-8')}
+{only_in_first_n3}
 ===
-{only_in_second.serialize(format='n3').decode('utf-8')}
+{only_in_second_n3}
 >>>
-""")
+""",
+    )
 
 
 @then("the TriG should contain")
 def step_impl(context):
     test_graph_diff(
-        Graph().parse(format='trig', data=context.trig),
-        Graph().parse(format='trig', data=context.text)
+        Graph().parse(format="trig", data=context.trig),
+        Graph().parse(format="trig", data=context.text),
     )
 
 
 @then('the TriG at "{trig_file}" should contain')
 def step_impl(context, trig_file):
     test_graph_diff(
-        Graph().parse(format='trig', source=trig_file),
-        Graph().parse(format='trig', data=context.text)
+        Graph().parse(format="trig", source=trig_file),
+        Graph().parse(format="trig", data=context.text),
     )
 
 
@@ -72,21 +90,21 @@ def step_impl(context, file):
 @step("the RDF should contain")
 def step_impl(context):
     test_graph_diff(
-        Graph().parse(format='turtle', data=context.turtle),
-        Graph().parse(format='turtle', data=context.text)
+        Graph().parse(format="turtle", data=context.turtle),
+        Graph().parse(format="turtle", data=context.text),
     )
 
 
 @step("the ask query '{query_file}' should return {expected_query_result}")
 def step_impl(context, query_file: str, expected_query_result: str):
-    query_file = Path('features') / 'fixtures' / query_file
+    query_file = Path("features") / "fixtures" / query_file
     with open(query_file) as f:
         query = f.read()
-    g = Graph().parse(format='turtle', data=context.turtle)
+    g = Graph().parse(format="turtle", data=context.turtle)
     results = list(g.query(query))
     ask_result = results[0]
     expected_ask_result = bool(distutils.util.strtobool(expected_query_result))
-    assert(ask_result == expected_ask_result)
+    assert ask_result == expected_ask_result
 
 
 @step("set the family to '{family}'")
@@ -108,7 +126,7 @@ def step_impl(context, datetime):
 @step("set the license to '{license}'")
 def step_impl(context, license):
     license_url = {
-        'OGLv3': 'http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/'
+        "OGLv3": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
     }.get(license)
     context.scraper.dataset.license = license_url
 
@@ -141,8 +159,8 @@ def step_impl(context, date):
 
 @then('the TriG should contain triples given by "{turtle_file}"')
 def step_impl(context, turtle_file):
-    with open(Path('features') / 'fixtures' / turtle_file) as f:
+    with open(Path("features") / "fixtures" / turtle_file) as f:
         test_graph_diff(
-            Graph().parse(format='trig', data=context.trig),
-            Graph().parse(format='turtle', file=f)
+            Graph().parse(format="trig", data=context.trig),
+            Graph().parse(format="turtle", file=f),
         )

--- a/gssutils/scrape.py
+++ b/gssutils/scrape.py
@@ -457,7 +457,7 @@ class Scraper:
         return quads
 
     def generate_trig(self, catalog_id=None) -> bytes:
-        return self.as_quads(catalog_id).serialize(format="trig", encoding="uts-8")
+        return self.as_quads(catalog_id).serialize(format="trig", encoding="utf-8")
 
     @property
     def title(self):

--- a/gssutils/scrapers/statswales.py
+++ b/gssutils/scrapers/statswales.py
@@ -5,37 +5,53 @@ import rdflib
 from dateutil.parser import parse
 from rdflib import RDF, URIRef
 from rdflib.namespace import DCTERMS
+from pyRdfa import pyRdfa as rdfa_processor, Options, HostLanguage
 
-import gssutils.metadata.dcat
 from gssutils.metadata import DCAT, GOV
 from gssutils.metadata.dcat import Distribution
 
 
 def scrape(scraper, tree):
-    pageGraph = rdflib.Graph()
     page = StringIO(scraper.session.get(scraper.uri).text)
-    pageGraph.parse(page, format="html")
+    pageGraph = _parse_rdfa_to_graph(page)
+    # pageGraph.parse(page, format="html")
     dataset = pageGraph.value(predicate=RDF.type, object=DCAT.Dataset, any=False)
     scraper.dataset.title = pageGraph.value(dataset, DCTERMS.title).value.strip()
-    scraper.dataset.comment = pageGraph.value(dataset, DCTERMS.description).value.strip()
+    scraper.dataset.comment = pageGraph.value(
+        dataset, DCTERMS.description
+    ).value.strip()
     license = str(pageGraph.value(dataset, DCTERMS.license))
-    if license == 'http://www.nationalarchives.gov.uk/doc/open-government-licence':
-        scraper.dataset.license = 'http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/'
+    if license == "http://www.nationalarchives.gov.uk/doc/open-government-licence":
+        scraper.dataset.license = (
+            "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+        )
     else:
         scraper.dataset.license = license
     publisher = pageGraph.value(dataset, DCTERMS.publisher)
-    if publisher == URIRef('http://www.gov.wales/'):
-        scraper.dataset.publisher = GOV['welsh-government']
+    if publisher == URIRef("http://www.gov.wales/"):
+        scraper.dataset.publisher = GOV["welsh-government"]
     else:
         scraper.dataset.publisher = publisher
-    scraper.dataset.issued = parse(pageGraph.value(dataset, DCTERMS.created), dayfirst=True).date()
-    scraper.dataset.modified = parse(pageGraph.value(dataset, DCTERMS.modified), dayfirst=True).date()
+    scraper.dataset.issued = parse(
+        pageGraph.value(dataset, DCTERMS.created), dayfirst=True
+    ).date()
+    scraper.dataset.modified = parse(
+        pageGraph.value(dataset, DCTERMS.modified), dayfirst=True
+    ).date()
     for pageDist in pageGraph.subjects(RDF.type, DCAT.Distribution):
         dist = Distribution(scraper)
         dist.title = pageGraph.value(pageDist, DCTERMS.title).value.strip()
         # Access URLs seem to have spaces in their query strings
         url_parts = urlparse(pageGraph.value(pageDist, DCAT.accessURL))
-        dist.downloadURL = url_parts._replace(query=url_parts.query.replace(' ', '+')).geturl()
+        dist.downloadURL = url_parts._replace(
+            query=url_parts.query.replace(" ", "+")
+        ).geturl()
         dist.mediaType = pageGraph.value(pageDist, DCAT.mediaType).value.strip()
         scraper.distributions.append(dist)
 
+
+def _parse_rdfa_to_graph(page: StringIO) -> rdflib.Graph:
+    options = Options()
+    options.host_language = HostLanguage.html5
+    processor = rdfa_processor(options)
+    return processor.graph_from_source(page)

--- a/gssutils/transform/cubes.py
+++ b/gssutils/transform/cubes.py
@@ -17,8 +17,14 @@ class Cubes:
     A class representing multiple datacubes
     """
 
-    def __init__(self, info_json="info.json", destination_path="out", base_uri="http://gss-data.org.uk",
-                 job_name=None, codelists_path: Optional[str] = None):
+    def __init__(
+        self,
+        info_json="info.json",
+        destination_path="out",
+        base_uri="http://gss-data.org.uk",
+        job_name=None,
+        codelists_path: Optional[str] = None,
+    ):
 
         with open(info_json, "r") as info_file:
             self.info = json.load(info_file)
@@ -33,23 +39,43 @@ class Cubes:
         self.local_codelists: Optional[str] = None
         if codelists_path is not None:
             self.local_codelists = codelists_path
-        elif (Path(destination_path) / '..' / 'codelists').exists():
+        elif (Path(destination_path) / ".." / "codelists").exists():
             self.local_codelists = "../codelists"
         self.cubes = []
         self.has_ran = False
-        
-        if job_name is not None:
-            logging.warning("The passing of job_name= has been depreciated and no longer does anything, please"
-                            "remove this keyword argument")
 
-    def add_cube(self, scraper, dataframe, title, graph=None, info_json_dict=None, override_containing_graph=None,
-                 suppress_catalog_and_dsd_output: bool = False):
+        if job_name is not None:
+            logging.warning(
+                "The passing of job_name= has been depreciated and no longer does anything, please"
+                "remove this keyword argument"
+            )
+
+    def add_cube(
+        self,
+        scraper,
+        dataframe,
+        title,
+        graph=None,
+        info_json_dict=None,
+        override_containing_graph=None,
+        suppress_catalog_and_dsd_output: bool = False,
+    ):
         """
         Add a single datacube to the cubes class.
         """
-        self.cubes.append(Cube(self.base_uri, scraper, dataframe, title, graph, info_json_dict,
-                               override_containing_graph, suppress_catalog_and_dsd_output,
-                               self.local_codelists))
+        self.cubes.append(
+            Cube(
+                self.base_uri,
+                scraper,
+                dataframe,
+                title,
+                graph,
+                info_json_dict,
+                override_containing_graph,
+                suppress_catalog_and_dsd_output,
+                self.local_codelists,
+            )
+        )
 
     def output_all(self):
         """
@@ -57,14 +83,18 @@ class Cubes:
         """
 
         if len(self.cubes) == 0:
-            raise Exception("Please add at least one datacube with '.add_cube' before "
-                            "calling output_all().")
+            raise Exception(
+                "Please add at least one datacube with '.add_cube' before "
+                "calling output_all()."
+            )
 
         # Don't let people add 1, output 1, add 2 output 2 etc
         # They'll want to but it'll mangle the url namespacing
         if self.has_ran:
-            raise Exception("Calling 'output_all' on the Cubes class is a destructive process and "
-                            "has already run. You need to (re)add all your datacubes before doing so.")
+            raise Exception(
+                "Calling 'output_all' on the Cubes class is a destructive process and "
+                "has already run. You need to (re)add all your datacubes before doing so."
+            )
 
         # Are we outputting more than one cube? We need to know this before we output
         is_multi_cube = len(self.cubes) >= 2
@@ -72,6 +102,7 @@ class Cubes:
         # The many-to-one scenario
         # If all cubes are getting written to a single graph it plays hell with the
         # single vs multiple namespaces logic, so we're going to explicitly check for and handle that
+        is_many_to_one = False
         is_many_to_one = False
         if is_multi_cube:
             to_graph_statements = [x.graph for x in self.cubes if x.graph is not None]
@@ -81,10 +112,15 @@ class Cubes:
 
         for cube in self.cubes:
             try:
-                cube.output(self.destination_folder, is_multi_cube, is_many_to_one, self.info)
+                cube.output(
+                    self.destination_folder, is_multi_cube, is_many_to_one, self.info
+                )
             except Exception as err:
-                raise Exception("Exception encountered while processing datacube '{}'." \
-                                .format(cube.title)) from err
+                raise Exception(
+                    "Exception encountered while processing datacube '{}'.".format(
+                        cube.title
+                    )
+                ) from err
         self.has_ran = True
 
 
@@ -92,19 +128,35 @@ class Cube:
     """
     A class to encapsulate the dataframe and associated metadata that constitutes a single datacube
     """
+
     override_containing_graph_uri: Optional[str]
 
-    def __init__(self, base_uri, scraper, dataframe, title, graph, info_json_dict,
-                 override_containing_graph_uri: Optional[str], suppress_catalog_and_dsd_output: bool,
-                 local_codelists: Optional[str] = None):
+    def __init__(
+        self,
+        base_uri,
+        scraper,
+        dataframe,
+        title,
+        graph,
+        info_json_dict,
+        override_containing_graph_uri: Optional[str],
+        suppress_catalog_and_dsd_output: bool,
+        local_codelists: Optional[str] = None,
+    ):
 
-        self.scraper = scraper  # note - the metadata of a scrape, not the actual data source
+        self.scraper = (
+            scraper  # note - the metadata of a scrape, not the actual data source
+        )
         self.dataframe = dataframe
         self.title = title
         self.scraper.set_base_uri(base_uri)
         self.graph = graph
-        self.info_json_dict = copy.deepcopy(info_json_dict)  # don't copy a pointer, snapshot a thing
-        self.override_containing_graph_uri: Optional[URI] = URI(override_containing_graph_uri)
+        self.info_json_dict = copy.deepcopy(
+            info_json_dict
+        )  # don't copy a pointer, snapshot a thing
+        self.override_containing_graph_uri: Optional[URI] = URI(
+            override_containing_graph_uri
+        )
         self.suppress_catalog_and_dsd_output = suppress_catalog_and_dsd_output
         self.local_codelists = local_codelists
 
@@ -120,10 +172,14 @@ class Cube:
 
         map_obj.set_accretive_upload(info_json)
         map_obj.set_mapping(info_json)
-        map_obj.set_suppress_catalog_and_dsd_output(self.suppress_catalog_and_dsd_output)
+        map_obj.set_suppress_catalog_and_dsd_output(
+            self.suppress_catalog_and_dsd_output
+        )
 
-        map_obj.set_csv(destination_folder / f'{pathified_title}.csv')
-        map_obj.set_dataset_uri(urljoin(self.scraper._base_uri, f'data/{self.scraper._dataset_id}'))
+        map_obj.set_csv(destination_folder / f"{pathified_title}.csv")
+        map_obj.set_dataset_uri(
+            urljoin(self.scraper._base_uri, f"data/{self.scraper._dataset_id}")
+        )
 
         if self.local_codelists is not None:
             map_obj.set_local_codelist_base(self.local_codelists)
@@ -135,8 +191,7 @@ class Cube:
 
         return map_obj
 
-    def _populate_csvw_mapping(self, destination_folder, pathified_title,
-                               info_json):
+    def _populate_csvw_mapping(self, destination_folder, pathified_title, info_json):
         """
         Use the provided details object to generate then fully populate the mapping class
         """
@@ -158,38 +213,60 @@ class Cube:
         else:
             primary_family = pathify(self.scraper.dataset.family)
 
-        main_dataset_id = info_json.get('id', Path.cwd().name)
+        main_dataset_id = info_json.get("id", Path.cwd().name)
         if is_many_to_one:
             # Sanity check, because this isn't an obvious as I'd like / a bit weird
-            err_msg = 'Aborting. Where you are writing multiple cubes to a single output graph, the ' \
-                      + 'pathified graph specified needs to match you pathified current working directory. ' \
-                      + 'Got "{}", expected "{}".'.format(graph_name, pathify(Path(os.getcwd()).name))
+            err_msg = (
+                "Aborting. Where you are writing multiple cubes to a single output graph, the "
+                + "pathified graph specified needs to match you pathified current working directory. "
+                + 'Got "{}", expected "{}".'.format(
+                    graph_name, pathify(Path(os.getcwd()).name)
+                )
+            )
             assert main_dataset_id == graph_name, err_msg
 
-            logging.warning("Output Scenario 1: Many cubes written to the default output (cwd())")
-            dataset_path = f'gss_data/{primary_family}/{graph_name}'
+            logging.warning(
+                "Output Scenario 1: Many cubes written to the default output (cwd())"
+            )
+            dataset_path = f"gss_data/{primary_family}/{graph_name}"
         elif is_multi_cube:
-            logging.warning("Output Scenario 2: Many cubes written to many stated outputs")
-            dataset_path = f'gss_data/{primary_family}/{main_dataset_id}/{graph_name}'
+            logging.warning(
+                "Output Scenario 2: Many cubes written to many stated outputs"
+            )
+            dataset_path = f"gss_data/{primary_family}/{main_dataset_id}/{graph_name}"
         else:
-            logging.warning("Output Scenario 3: A single cube written to the default output (cwd())")
-            dataset_path = f'gss_data/{primary_family}/{main_dataset_id}'
+            logging.warning(
+                "Output Scenario 3: A single cube written to the default output (cwd())"
+            )
+            dataset_path = f"gss_data/{primary_family}/{main_dataset_id}"
         self.scraper.set_dataset_id(dataset_path)
 
         # output the tidy data
-        self.dataframe.to_csv(destination_folder / f'{pathify(self.title)}.csv', index=False)
+        self.dataframe.to_csv(
+            destination_folder / f"{pathify(self.title)}.csv", index=False
+        )
 
-        is_accretive_upload = info_json is not None and "load" in info_json and "accretiveUpload" in info_json["load"] \
-                              and info_json["load"]["accretiveUpload"]
+        is_accretive_upload = (
+            info_json is not None
+            and "load" in info_json
+            and "accretiveUpload" in info_json["load"]
+            and info_json["load"]["accretiveUpload"]
+        )
 
         # Don't output trig file if we're performing an accretive upload (or we have been asked to suppress it).
         # We don't want to duplicate information we already have.
         if not is_accretive_upload and not self.suppress_catalog_and_dsd_output:
             # Output the trig
             trig_to_use = self.scraper.generate_trig()
-            with open(destination_folder / f'{pathify(self.title)}.csv-metadata.trig', 'wb') as metadata:
+            with open(
+                destination_folder / f"{pathify(self.title)}.csv-metadata.trig", "wb"
+            ) as metadata:
                 metadata.write(trig_to_use)
 
         # Output csv and csvw
-        populated_map_obj = self._populate_csvw_mapping(destination_folder, pathify(self.title), info_json)
-        populated_map_obj.write(destination_folder / f'{pathify(self.title)}.csv-metadata.json')
+        populated_map_obj = self._populate_csvw_mapping(
+            destination_folder, pathify(self.title), info_json
+        )
+        populated_map_obj.write(
+            destination_folder / f"{pathify(self.title)}.csv-metadata.json"
+        )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="gssutils",
-    version_format='{tag}.dev{commitcount}+{gitsha}',
+    version_format="{tag}.dev{commitcount}+{gitsha}",
     author="Alex Tucker",
     author_email="alex@floop.org.uk",
     description="Common functions used by GSS data transformations",
@@ -13,32 +13,37 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/GSS-Cogs/gss-utils",
     packages=setuptools.find_packages(),
-    setup_requires=['better-setuptools-git-version'],
-    install_requires=['requests',
-                      'python_dateutil',
-                      'CacheControl',
-                      'lockfile',
-                      'databaker @ git+git://github.com/GSS-Cogs/databaker.git@2ddb86121eb563e3a37ee1106529d8b1da197e31#egg=databaker',
-                      'ipython',
-                      'jinja2',
-                      'pandas',
-                      'html2text',
-                      'rdflib==4.2.2',
-                      'rdflib-jsonld',
-                      'lxml',
-                      'unidecode',
-                      'argparse',
-                      'wheel',
-                      'uritemplate',
-                      'backoff',
-                      'vcrpy'],
-    tests_require=['behave', 'parse', 'nose', 'vcrpy', 'docker'],
+    setup_requires=["better-setuptools-git-version"],
+    install_requires=[
+        "requests",
+        "python_dateutil",
+        "CacheControl",
+        "lockfile",
+        "databaker @ git+git://github.com/GSS-Cogs/databaker.git@2ddb86121eb563e3a37ee1106529d8b1da197e31#egg=databaker",
+        "ipython",
+        "jinja2",
+        "pandas",
+        "html2text",
+        "rdflib",
+        "rdflib-jsonld",
+        "lxml",
+        "unidecode",
+        "argparse",
+        "wheel",
+        "uritemplate",
+        "backoff",
+        "vcrpy",
+        "pyRdfa3",
+    ],
+    tests_require=["behave", "parse", "nose", "vcrpy", "docker"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
     entry_points={
-        'console_scripts': ['codelist-manager=gssutils.codelistmanager.main:codelist_manager']
-    }
+        "console_scripts": [
+            "codelist-manager=gssutils.codelistmanager.main:codelist_manager"
+        ]
+    },
 )


### PR DESCRIPTION
Using the [pyRDFa](https://github.com/RDFLib/pyrdfa3) library to perform RDFa -> `rdflib.Graph` conversion.

This implicitly upgrades rdflib to the latest current version, 6.0.0

N.B. I have the [black](https://pypi.org/project/black/) autoformatter installed which has altered the layout of a few of the files I made changes in.
