### PR TITLE
Adding workaround to license issue

### DIFF
--- a/gssutils/scrapers/defra.py
+++ b/gssutils/scrapers/defra.py
@@ -83,7 +83,10 @@ def scrape_dataset(scraper, dataset_uri: str, contact_point: str, identifier: st
 
     dataset.description = description_text
 
-    dataset.license = assert_get_one(tree.xpath("//div[@id='oglLicense']/a"), "licence in use").get("href")
+    try:
+        dataset.license = assert_get_one(tree.xpath("//div[@id='oglLicense']/a"), "licence in use").get("href")
+    except:
+        dataset.license = "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
 
     # we want the text from a table row <tr> that contains a table header <th> of text "Date last updated"
     issued_row_element = assert_get_one(tree.xpath("//tr/th[contains(text(),'Date last updated')]/parent::*"),


### PR DESCRIPTION
will print warning and then use default license