### PR TITLE
add primitive retries

### DIFF
--- a/gssutils/scrapers/ons.py
+++ b/gssutils/scrapers/ons.py
@@ -1,21 +1,18 @@
-from distutils.util import strtobool
-import logging
-import os
-
 from csv import DictReader
 from io import StringIO
+import logging
+import mimetypes
+import os
+from urllib.parse import urlparse, urlunparse
 
 import backoff
 from dateutil import tz
 from dateutil.parser import parse, isoparse
-
-from urllib.parse import urlparse, urlunparse
-
+from distutils.util import strtobool
 
 from gssutils.metadata.dcat import Distribution
 from gssutils.metadata.mimetype import Excel, ODS, CSV, ExcelOpenXML, CSDB
 
-import mimetypes
 
 # save ourselves some typing later
 ONS_PREFIX = "https://www.ons.gov.uk"

--- a/gssutils/scrapers/ons.py
+++ b/gssutils/scrapers/ons.py
@@ -225,8 +225,6 @@ def handler_dataset_landing_page(scraper, landing_page, tree):
         # iterate through the lot, we're aiming to create at least one distribution object for each
         for i, version_dict in enumerate(versions_dict_list):
 
-            version_dict = versions_dict_list[i]
-
             version_url = version_dict["url"]
             issued = version_dict["issued"]
 

--- a/gssutils/scrapers/ons.py
+++ b/gssutils/scrapers/ons.py
@@ -1,10 +1,10 @@
 import logging
-import json
 import os
 
 from csv import DictReader
 from io import StringIO
 
+import backoff
 from dateutil import tz
 from dateutil.parser import parse, isoparse
 from retrying import retry
@@ -37,7 +37,7 @@ def get(url, scraper):
     return r.json()
 
 
-@retry(wait_exponential_multiplier=1000, wait_exponential_max=10000, stop_max_delay=30000)
+@backoff.on_exception(backoff.expo, Exception, max_time=30)
 def retry_get(url, scraper):
     """ Given a url, return a dict, with retries for errors"""
     try:

--- a/gssutils/scrapers/ons.py
+++ b/gssutils/scrapers/ons.py
@@ -7,7 +7,6 @@ from io import StringIO
 import backoff
 from dateutil import tz
 from dateutil.parser import parse, isoparse
-from retrying import retry
 from urllib.parse import urlparse, urlunparse
 
 from gssutils.metadata.dcat import Distribution

--- a/gssutils/scrapers/ons.py
+++ b/gssutils/scrapers/ons.py
@@ -1,3 +1,4 @@
+from distutils.util import strtobool
 import logging
 import os
 
@@ -7,7 +8,9 @@ from io import StringIO
 import backoff
 from dateutil import tz
 from dateutil.parser import parse, isoparse
+
 from urllib.parse import urlparse, urlunparse
+
 
 from gssutils.metadata.dcat import Distribution
 from gssutils.metadata.mimetype import Excel, ODS, CSV, ExcelOpenXML, CSDB
@@ -22,7 +25,7 @@ ONS_TOPICS_CSV = 'https://gss-cogs.github.io/ref_common/reference/codelists/ons-
 
 def get_dict_from_json_url(url, scraper):
     """ Wrapper to Let the DE decide if they want retries or not via an env var"""
-    if bool(os.getenv("ONS_SCRAPER_RETRIES", None)):
+    if strtobool(os.getenv("ONS_SCRAPER_RETRIES", "False")):
         return retry_get(url, scraper)
     return get(url, scraper)
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
         "uritemplate",
         "backoff",
         "vcrpy",
-        "pyRdfa3",
+        "pyRdfa3"
     ],
     tests_require=["behave", "parse", "nose", "vcrpy", "docker"],
     classifiers=[


### PR DESCRIPTION
Getting issues where (we seem, it's hard to tell) to be getting 200 responses from a json endpoint on the ONS website but with no content in them (so spawns JsonDecode errors). This appears to happen inconsistently.

Not sure why.
Not sure why I can only recreate it in a container.
Not sure why its inconsistent (its not the same urls that break each time).
Not sure if its just the ONS scraper (hopefully).

Have wanted retry logic for a while anyway, so this PR adds optional (env var to turn it on) retry logic for the ONS scraper. 100% not _the_ solution, but a thing worth having and gets any effected ONS pipelines back to working in the meantime.

Also did a bit of a clean up since I was in there anyway. Lots of red but its just removing excessive comments (this was an example script back in the day) and replacing all the separate http gets with a single function.

Usage, just set an env var to turn it on, i.e `os.environ["ONS_SCRAPER_RETRIES"] = "True"` at the top of the script or set it in your terminal.